### PR TITLE
fix: set status code to 500 by default

### DIFF
--- a/src/responseError.ts
+++ b/src/responseError.ts
@@ -13,6 +13,6 @@ export class ResponseError extends Error {
     this.response = response
 
     this.code = response.status === 404 ? "ENOENT" : null
-    this.status = this.statusCode = response.status
+    this.status = this.statusCode = response.status || 500
   }
 }


### PR DESCRIPTION
In some cases, the API call throws and doesn't have any status code. At least listings relies on having a status code in order to show the correct error page. This results in https://autoricardo.atlassian.net/browse/CAR-2520

An example is https://sentry.io/organizations/carforyou/issues/1274087523/?project=1266162 and I think it happens when the browser does not even do the API call. This happens in the above case because there's a problem with the certificate, but I could also imagine it happening for cancelled or in some form blocked requests