### PR TITLE
chore: rename npm run test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          command: npm run test:unit -- --maxWorkers=4
+          command: npm run test -- --maxWorkers=4
           no_output_timeout: 3m
       - notify_slack_failure
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "tslint --project tsconfig.lint.json",
     "format": "tslint --project tsconfig.lint.json --fix",
     "typecheck": "tsc --noEmit",
-    "test:unit": "jest",
-    "test:unit:debug": "node --inspect-brk --inspect=127.0.0.1:9229 ./node_modules/jest/bin/jest.js --runInBand"
+    "test": "jest",
+    "test:debug": "node --inspect-brk --inspect=127.0.0.1:9229 ./node_modules/jest/bin/jest.js --runInBand"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I propose to rename `npm run test:unit` to just `npm run test` because there is only one type of test in this repo. also this is in sync with the tasks we have for `listings`, where `npm run test` runs the unit tests too