### PR TITLE
feat: add fields to product object

### DIFF
--- a/src/types/models/product.ts
+++ b/src/types/models/product.ts
@@ -1,7 +1,9 @@
 export interface Product {
   id: number
   price: number
-  productKey: string
+  standardPrice: number
+  validity?: number
+  feature: string
 }
 
 export interface PurchaseAndUseProduct {


### PR DESCRIPTION
Extensions to product API for https://autoricardo.atlassian.net/browse/CAR-3981

To summarize:
- add `standardPrice` field - this is a price before any discount. If the product is not discounted it will be same as the `price`
- add `feature` field - this is a feature that product enables
- add `validity` field - this is how long the product is valid (in seconds). It's an optional field.
- remove `productKey` field - it was meant to use by salesforce I don't want to accidentally introduce coupling FE to salesforce by exposing this field to FE applications. `feature` and `id` should be enough for us according to Sinisa