### PR TITLE
chore: fix slack orb config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,17 +3,6 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
 
-commands:
-  slack/notify-on-failure:
-    steps:
-      - run:
-          name: Notify Slack of failure if on master
-          command: |
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
-              curl -X POST -H 'Content-type: application/json' --data "{\"text\":\":boom: ${CIRCLE_JOB} failed: ${CIRCLE_BUILD_URL}\"}" https://hooks.slack.com/services/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
-            fi
-          when: on_fail
-
 docker: &DOCKER_NODE
   docker:
     - image: circleci/node:10.20
@@ -36,7 +25,8 @@ jobs:
           root: ~/
           paths:
             - project
-      - slack/notify-on-failure
+      - slack/notify-on-failure:
+          only_for_branches: master
 
   build:
     <<: *DOCKER_NODE
@@ -51,7 +41,8 @@ jobs:
           root: ~/
           paths:
             - project/pkg
-      - slack/notify-on-failure
+      - slack/notify-on-failure:
+          only_for_branches: master
 
   unit:
     <<: *DOCKER_NODE
@@ -62,7 +53,8 @@ jobs:
       - run:
           command: npm run test:unit -- --maxWorkers=4
           no_output_timeout: 3m
-      - slack/notify-on-failure
+      - slack/notify-on-failure:
+          only_for_branches: master
 
   lint:
     <<: *DOCKER_NODE
@@ -73,7 +65,8 @@ jobs:
       - run:
           command: npm run lint
           no_output_timeout: 3m
-      - slack/notify-on-failure
+      - slack/notify-on-failure:
+          only_for_branches: master
 
   typecheck:
     <<: *DOCKER_NODE
@@ -84,7 +77,8 @@ jobs:
       - run:
           command: npm run typecheck
           no_output_timeout: 1m
-      - slack/notify-on-failure
+      - slack/notify-on-failure:
+          only_for_branches: master
 
   release:
     <<: *DOCKER_NODE
@@ -92,7 +86,8 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: npx semantic-release
-      - slack/notify-on-failure
+      - slack/notify-on-failure:
+          only_for_branches: master
 
   pre_release:
     <<: *DOCKER_NODE
@@ -101,7 +96,8 @@ jobs:
           at: ~/
       # manually set PR shell variables to empty to build pull request
       - run: CI_PULL_REQUEST= CIRCLE_PULL_REQUEST= npx semantic-release
-      - slack/notify-on-failure
+      - slack/notify-on-failure:
+          only_for_branches: master
 
 workflows:
   version: 2


### PR DESCRIPTION
We did not set the slack orb to only post notifications for failures on the master.
This fixes it.