### PR TITLE
fix: add missing properties for search listing type

### DIFF
--- a/src/types/models/listing.ts
+++ b/src/types/models/listing.ts
@@ -177,6 +177,10 @@ export interface SearchListing {
   publishingDate: string
   externalListingId: string
   enabledFeatures: Feature[]
+  driveType: string
+  bodyColorGroup: string
+  conditionType: string
+  consumptionCategory: string
 }
 
 export interface DetailListing extends Listing {


### PR DESCRIPTION
﻿Some of the properties returned by the search service for the listing are missing
https://inventory-search-service.preprod.carforyou.ch/swagger-ui.html#/Listing%20Search/searchUsingPOST

