### PR TITLE
feat: add pdpViewsByFeature to ListingAnalyticsStats

### DIFF
--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -167,6 +167,9 @@ export interface ListingAnalyticsStats {
   callLeads: number
   messageLeads: number
   pdpViews: number
+  pdpViewsByFeature: {
+    [key: string]: number
+  }
 }
 export interface ListingAnalyticsData {
   id: number


### PR DESCRIPTION
Extends listing analytics statistics by new `pdpViewsByFeature` statistic as described here:
https://autoricardo-ag.slack.com/archives/C0162APB0ET/p1593782639006900