### PR TITLE
feat: add leasing interest call

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Also accompanying modes and param types, as well as default values, are exported
   - [`sendMessageLead`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Lead/createMessageLeadUsingPOST)
 - [Leasing](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing)
   - [`fetchLeasingFormUrl`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/generateLeasingProviderFormUrlUsingPOST)
+  - [`sendLeasingInterest`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/createLeasingInterestUsingPOST)
 - [Money Back Guarantee](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Money_Back_Guarantee)
   - [`sendMoneybackApplication`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Money%20Back%20Guarantee/createMbgApplicationUsingPOST)
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Also accompanying modes and param types, as well as default values, are exported
   - [`fetchTransmissionTypes`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory%20Data/getTransmissionTypesUsingGET)
 - [Lead](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Lead)
   - [`sendMessageLead`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Lead/createMessageLeadUsingPOST)
+- [Leasing](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing)
+  - [`fetchLeasingFormUrl`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/generateLeasingProviderFormUrlUsingPOST)
 - [Money Back Guarantee](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Money_Back_Guarantee)
   - [`sendMoneybackApplication`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Money%20Back%20Guarantee/createMbgApplicationUsingPOST)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,7 @@ export {
 } from "./services/car/inventoryData"
 export { sendMoneybackApplication } from "./services/car/moneybackApplication"
 export { sendMessageLead } from "./services/car/messageLead"
+export { fetchLeasingFormUrl } from "./services/car/leasing"
 
 export {
   fetchListingOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,10 @@ export {
 } from "./services/car/inventoryData"
 export { sendMoneybackApplication } from "./services/car/moneybackApplication"
 export { sendMessageLead } from "./services/car/messageLead"
-export { fetchLeasingFormUrl } from "./services/car/leasing"
+export {
+  fetchLeasingFormUrl,
+  sendLeasingInterest,
+} from "./services/car/leasing"
 
 export {
   fetchListingOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   ImageEnrichment,
   SavedSearch,
   MessageLead,
+  LeasingInterest,
   MoneybackApplication,
   City,
   PresignedUrl,

--- a/src/services/car/__tests__/leasing.test.ts
+++ b/src/services/car/__tests__/leasing.test.ts
@@ -1,0 +1,25 @@
+import { fetchLeasingFormUrl } from "../leasing"
+
+describe("CAR service", () => {
+  beforeEach(fetchMock.resetMocks)
+
+  describe("fetchLeasingFormUrl", () => {
+    it("returns the url", async () => {
+      fetchMock.mockResponse(JSON.stringify({ url: "test-url" }))
+
+      expect(
+        await fetchLeasingFormUrl({ listingId: 123, locale: "de" })
+      ).toEqual("test-url")
+    })
+
+    it("returns null if listing fails validation rules", async () => {
+      fetchMock.mockResponse(JSON.stringify({ message: "too expensive" }), {
+        status: 422,
+      })
+
+      expect(
+        await fetchLeasingFormUrl({ listingId: 123, locale: "de" })
+      ).toEqual(null)
+    })
+  })
+})

--- a/src/services/car/__tests__/leasing.test.ts
+++ b/src/services/car/__tests__/leasing.test.ts
@@ -1,4 +1,4 @@
-import { fetchLeasingFormUrl } from "../leasing"
+import { fetchLeasingFormUrl, sendLeasingInterest } from "../leasing"
 
 describe("CAR service", () => {
   beforeEach(fetchMock.resetMocks)
@@ -20,6 +20,119 @@ describe("CAR service", () => {
       expect(
         await fetchLeasingFormUrl({ listingId: 123, locale: "de" })
       ).toEqual(null)
+    })
+  })
+
+  describe("sendLeasingInterest", () => {
+    const leasingInterest = (attributes = {}) => ({
+      name: "Test",
+      phone: "+41781234567",
+      email: "test@test.com",
+      message: "This is a message of a interested customer",
+      ...attributes,
+    })
+
+    describe("valid parameters", () => {
+      beforeEach(() => {
+        fetchMock.mockResponse("")
+      })
+
+      describe("validate only", () => {
+        it("calls validation endpoint", async () => {
+          await sendLeasingInterest(12345, leasingInterest(), {
+            validateOnly: true,
+          })
+
+          expect(fetch).toHaveBeenCalledWith(
+            expect.stringMatching(
+              /\/listings\/12345\/leasing\/interests\/validate$/
+            ),
+            expect.any(Object)
+          )
+        })
+
+        it("returns a success", async () => {
+          const result = await sendLeasingInterest(12345, leasingInterest(), {
+            validateOnly: true,
+          })
+
+          expect(result).toEqual({ tag: "success", result: leasingInterest() })
+        })
+      })
+
+      describe("submit", () => {
+        it("calls submission endpoint", async () => {
+          await sendLeasingInterest(12345, leasingInterest())
+
+          expect(fetch).toHaveBeenCalledWith(
+            expect.stringMatching(/\/listings\/12345\/leasing\/interests$/),
+            expect.any(Object)
+          )
+        })
+
+        it("sends recaptcha token in a header", async () => {
+          await sendLeasingInterest(12345, leasingInterest(), {
+            recaptchaToken: "token",
+          })
+
+          expect(fetch).toHaveBeenCalledWith(expect.any(String), {
+            headers: expect.objectContaining({
+              "Recaptcha-Token": "token",
+            }),
+            body: expect.any(String),
+            method: "POST",
+          })
+        })
+
+        it("returns a success", async () => {
+          const result = await sendLeasingInterest(12345, leasingInterest())
+
+          expect(result).toEqual({ tag: "success", result: leasingInterest() })
+        })
+      })
+    })
+
+    describe("invalid parameters", () => {
+      const errors = [{ param: "email", error: "validations.invalid-format" }]
+
+      beforeEach(() => {
+        fetchMock.mockResponse(
+          JSON.stringify({ errors, message: "validations.not-valid" }),
+          {
+            status: 400,
+          }
+        )
+      })
+
+      it("returns a failure", async () => {
+        const result = await sendLeasingInterest(
+          12345,
+          leasingInterest({ email: "test@test" })
+        )
+
+        expect(result.tag).toEqual("error")
+        if (result.tag === "error") {
+          expect(result.errors).toEqual(errors)
+          expect(result.message).toEqual("validations.not-valid")
+        }
+      })
+    })
+
+    describe("other error", () => {
+      beforeEach(() => {
+        fetchMock.mockResponse("", {
+          status: 500,
+        })
+      })
+
+      it("returns a failure", async () => {
+        const result = await sendLeasingInterest(12345, leasingInterest())
+
+        expect(result.tag).toEqual("error")
+        if (result.tag === "error") {
+          expect(result.message).toEqual("validation.other-error")
+        }
+      })
     })
   })
 })

--- a/src/services/car/leasing.ts
+++ b/src/services/car/leasing.ts
@@ -1,6 +1,7 @@
 import { postData, Service, handleValidationError } from "../../base"
 
 import { WithValidationError } from "../../types/withValidationError"
+import { LeasingInterest } from "../../types/models"
 
 const wrappedFetchLeasingFormUrl = async ({
   listingId,
@@ -34,4 +35,38 @@ export const fetchLeasingFormUrl = async (args: {
     case "error":
       return null
   }
+}
+
+export const sendLeasingInterest = async (
+  listingId: number,
+  leasingInterest: LeasingInterest,
+  options = {}
+): Promise<WithValidationError<LeasingInterest>> => {
+  const { validateOnly, recaptchaToken } = {
+    validateOnly: false,
+    recaptchaToken: null,
+    ...options,
+  }
+
+  const path = `listings/${listingId}/leasing/interests${
+    validateOnly ? "/validate" : ""
+  }`
+
+  try {
+    await postData(
+      Service.CAR,
+      path,
+      leasingInterest,
+      recaptchaToken ? { "Recaptcha-Token": recaptchaToken } : {}
+    )
+
+    return {
+      tag: "success",
+      result: leasingInterest,
+    }
+  } catch (error) {
+    return handleValidationError(error, { swallowErrors: true })
+  }
+}
+
 }

--- a/src/services/car/leasing.ts
+++ b/src/services/car/leasing.ts
@@ -1,0 +1,37 @@
+import { postData, Service, handleValidationError } from "../../base"
+
+import { WithValidationError } from "../../types/withValidationError"
+
+const wrappedFetchLeasingFormUrl = async ({
+  listingId,
+  locale,
+}): Promise<WithValidationError<{ url: string }>> => {
+  try {
+    const result = await postData(
+      Service.CAR,
+      `listings/${listingId}/leasing/generate-provider-form-url`,
+      { language: locale }
+    )
+
+    return {
+      tag: "success",
+      result,
+    }
+  } catch (error) {
+    return handleValidationError(error, { swallowErrors: true })
+  }
+}
+
+export const fetchLeasingFormUrl = async (args: {
+  listingId: number
+  locale: string
+}): Promise<string | null> => {
+  const response = await wrappedFetchLeasingFormUrl(args)
+
+  switch (response.tag) {
+    case "success":
+      return response.result.url
+    case "error":
+      return null
+  }
+}

--- a/src/services/car/leasing.ts
+++ b/src/services/car/leasing.ts
@@ -68,5 +68,3 @@ export const sendLeasingInterest = async (
     return handleValidationError(error, { swallowErrors: true })
   }
 }
-
-}

--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -136,6 +136,14 @@ export interface MessageLead {
   }
 }
 
+export interface LeasingInterest {
+  email?: string
+  language?: string
+  message?: string
+  name?: string
+  phone?: string
+}
+
 export interface MoneybackApplication {
   email?: string
   language?: string


### PR DESCRIPTION
Adds `sendLeasingInterest` api call. It will behave the same way message leas call behaves in terms of validation.

~~**note** the validation part is not yet implemented in the backend~~