### PR TITLE
fix: add reCaptcha too the leasing call

### DIFF
--- a/src/services/car/__tests__/leasing.test.ts
+++ b/src/services/car/__tests__/leasing.test.ts
@@ -21,6 +21,25 @@ describe("CAR service", () => {
         await fetchLeasingFormUrl({ listingId: 123, locale: "de" })
       ).toEqual(null)
     })
+
+    it("sends recaptcha token in a header", async () => {
+      fetchMock.mockResponse(JSON.stringify({ url: "test-url" }))
+
+      await fetchLeasingFormUrl(
+        { listingId: 123, locale: "de" },
+        {
+          recaptchaToken: "token",
+        }
+      )
+
+      expect(fetch).toHaveBeenCalledWith(expect.any(String), {
+        headers: expect.objectContaining({
+          "Recaptcha-Token": "token",
+        }),
+        body: expect.any(String),
+        method: "POST",
+      })
+    })
   })
 
   describe("sendLeasingInterest", () => {

--- a/src/services/car/__tests__/messageLead.test.ts
+++ b/src/services/car/__tests__/messageLead.test.ts
@@ -39,7 +39,7 @@ describe("Car API", () => {
       )
     })
 
-    describe("valid parematers", () => {
+    describe("valid parameters", () => {
       beforeEach(() => {
         fetchMock.mockResponse("")
       })

--- a/src/services/car/leasing.ts
+++ b/src/services/car/leasing.ts
@@ -3,15 +3,16 @@ import { postData, Service, handleValidationError } from "../../base"
 import { WithValidationError } from "../../types/withValidationError"
 import { LeasingInterest } from "../../types/models"
 
-const wrappedFetchLeasingFormUrl = async ({
-  listingId,
-  locale,
-}): Promise<WithValidationError<{ url: string }>> => {
+const wrappedFetchLeasingFormUrl = async (
+  { listingId, locale },
+  { recaptchaToken = null } = {}
+): Promise<WithValidationError<{ url: string }>> => {
   try {
     const result = await postData(
       Service.CAR,
       `listings/${listingId}/leasing/generate-provider-form-url`,
-      { language: locale }
+      { language: locale },
+      recaptchaToken ? { "Recaptcha-Token": recaptchaToken } : {}
     )
 
     return {
@@ -23,11 +24,14 @@ const wrappedFetchLeasingFormUrl = async ({
   }
 }
 
-export const fetchLeasingFormUrl = async (args: {
-  listingId: number
-  locale: string
-}): Promise<string | null> => {
-  const response = await wrappedFetchLeasingFormUrl(args)
+export const fetchLeasingFormUrl = async (
+  args: {
+    listingId: number
+    locale: string
+  },
+  options = {}
+): Promise<string | null> => {
+  const response = await wrappedFetchLeasingFormUrl(args, options)
 
   switch (response.tag) {
     case "success":


### PR DESCRIPTION
Turns out that `fetchLeasingFormUrl` expects reCaptcha header to be passed to return value. This was missed in the initial implementation