### PR TITLE
fix: increase bundle size

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "pkg/dist-web/index.js",
-      "maxSize": "10 kB"
+      "maxSize": "15 kB"
     }
   ]
 }


### PR DESCRIPTION
The previous PR was a breaking change but didn't deploy, shall I merge this one as a breaking change or as a fix is ok?
And how can we block the PR in case the bundle size fails?