### PR TITLE
feat: accept language parameter in dealer fetch

### DIFF
--- a/src/services/__tests__/dealer.test.ts
+++ b/src/services/__tests__/dealer.test.ts
@@ -1,4 +1,5 @@
 import {
+  fetchDealer,
   fetchDealerSuggestions,
   fetchDealerProfile,
   putDealerProfile,
@@ -18,6 +19,26 @@ describe("Dealer", () => {
         `dealer.service.test/dealers/suggestions?q=${encodeURIComponent(
           query
         )}`,
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe("#fetchDealer", () => {
+    it("accepts language option", async () => {
+      await fetchDealer(123, { language: "de" })
+
+      expect(fetch).toHaveBeenCalledWith(
+        `dealer.service.test/dealers/123?language=de`,
+        expect.any(Object)
+      )
+    })
+
+    it("works without the language option", async () => {
+      await fetchDealer(123)
+
+      expect(fetch).toHaveBeenCalledWith(
+        "dealer.service.test/dealers/123",
         expect.any(Object)
       )
     })

--- a/src/services/dealer.ts
+++ b/src/services/dealer.ts
@@ -19,12 +19,8 @@ export const fetchDealer = async (
   id: number,
   options: { language?: "de" | "en" | "fr" | "it" } = {}
 ): Promise<Dealer> => {
-  return fetchPath(
-    Service.DEALER,
-    `dealers/${id}${
-      Object.keys(options).length ? `?${toQueryString(options)}` : ""
-    }`
-  )
+  const query = toQueryString(options)
+  return fetchPath(Service.DEALER, `dealers/${id}${query ? `?${query}` : ""}`)
 }
 
 export const fetchDealerSuggestions = async (

--- a/src/services/dealer.ts
+++ b/src/services/dealer.ts
@@ -21,7 +21,9 @@ export const fetchDealer = async (
 ): Promise<Dealer> => {
   return fetchPath(
     Service.DEALER,
-    `dealers/${id}${options.language ? `?${toQueryString(options)}` : ""}`
+    `dealers/${id}${
+      Object.keys(options).length ? `?${toQueryString(options)}` : ""
+    }`
   )
 }
 

--- a/src/services/dealer.ts
+++ b/src/services/dealer.ts
@@ -21,7 +21,7 @@ export const fetchDealer = async (
 ): Promise<Dealer> => {
   return fetchPath(
     Service.DEALER,
-    `dealers/${id}${options?.language ? `?${toQueryString(options)}` : ""}`
+    `dealers/${id}${options.language ? `?${toQueryString(options)}` : ""}`
   )
 }
 

--- a/src/services/dealer.ts
+++ b/src/services/dealer.ts
@@ -13,8 +13,16 @@ import { DealerPromotion } from "../types/models/dealerPromotion"
 import { WithValidationError } from "../types/withValidationError"
 import { withTokenRefresh } from "../tokenRefresh"
 
-export const fetchDealer = async (id: number): Promise<Dealer> => {
-  return fetchPath(Service.DEALER, `dealers/${id}`)
+import toQueryString from "../lib/toQueryString"
+
+export const fetchDealer = async (
+  id: number,
+  options: { language?: "de" | "en" | "fr" | "it" } = {}
+): Promise<Dealer> => {
+  return fetchPath(
+    Service.DEALER,
+    `dealers/${id}${options?.language ? `?${toQueryString(options)}` : ""}`
+  )
 }
 
 export const fetchDealerSuggestions = async (


### PR DESCRIPTION
Due to dealer promotion being created in multiple languages the `fetchDealer` call accepts an optional `language` option to get the right language version of promotion content.