### PR TITLE
feat: rename dealerCarouselPromotion to dealerPromotionContent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,18 +41,14 @@ export {
   ListingSource,
 } from "./types/models/listing"
 
-export {
-  DealerLocation,
-  DealerCarouselPromotion,
-  SearchDealer,
-} from "./types/models/dealerPromotion"
-
 export { SearchType, Type } from "./types/models/type"
 export { Facets, Facet } from "./types/facets"
 export { DealerProfile } from "./types/models/dealerProfile"
 export {
   DealerPromotion,
   DealerPromotionContent,
+  DealerLocation,
+  SearchDealer,
 } from "./types/models/dealerPromotion"
 
 export {

--- a/src/types/models/dealerPromotion.ts
+++ b/src/types/models/dealerPromotion.ts
@@ -23,15 +23,9 @@ export interface DealerLocation {
   zipCode: string
 }
 
-export interface DealerCarouselPromotion {
-  image: string
-  logo: string
-  title: string
-}
-
 export interface SearchDealer {
   id: number
   location: DealerLocation
   name: string
-  promotion: DealerCarouselPromotion
+  promotion: DealerPromotionContent
 }


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/CAR-4933

removed `dealerCarouselPromotion` and using `dealerPromotionContent`

@carforyou/frontend should i release a major version or a minor should be sufficient?