### PR TITLE
fix: there are no validation errors to handle on GET requests

### DIFF
--- a/src/services/dealer.ts
+++ b/src/services/dealer.ts
@@ -35,7 +35,9 @@ export const fetchDealerSuggestions = async (
 export const fetchDealerProfile = async (
   dealerId: number
 ): Promise<DealerProfile> =>
-  withTokenRefresh(fetchPath(Service.DEALER, `dealers/${dealerId}/profile`))
+  withTokenRefresh(async () =>
+    fetchPath(Service.DEALER, `dealers/${dealerId}/profile`)
+  )
 
 export const postDealerProfile = async (
   profile: Omit<DealerProfile, "id" | "dealerSourceGroup" | "dealerType">
@@ -82,14 +84,16 @@ export const putDealerProfile = async ({
 export const fetchDealerEntitlements = async (
   dealerId
 ): Promise<Entitlements> =>
-  withTokenRefresh(
+  withTokenRefresh(async () =>
     fetchPath(Service.DEALER, `dealers/${dealerId}/entitlements`)
   )
 
 export const fetchDealerPromotion = async (
   dealerId: number
 ): Promise<DealerPromotion> =>
-  withTokenRefresh(fetchPath(Service.DEALER, `dealers/${dealerId}/promotion`))
+  withTokenRefresh(async () =>
+    fetchPath(Service.DEALER, `dealers/${dealerId}/promotion`)
+  )
 
 export const postDealerPromotion = async (
   dealerId: number,

--- a/src/services/dealer.ts
+++ b/src/services/dealer.ts
@@ -35,17 +35,7 @@ export const fetchDealerSuggestions = async (
 export const fetchDealerProfile = async (
   dealerId: number
 ): Promise<DealerProfile> =>
-  withTokenRefresh(async () => {
-    try {
-      const response = await fetchPath(
-        Service.DEALER,
-        `dealers/${dealerId}/profile`
-      )
-      return response
-    } catch (error) {
-      return handleValidationError(error, { swallowErrors: true })
-    }
-  })
+  withTokenRefresh(fetchPath(Service.DEALER, `dealers/${dealerId}/profile`))
 
 export const postDealerProfile = async (
   profile: Omit<DealerProfile, "id" | "dealerSourceGroup" | "dealerType">
@@ -92,32 +82,14 @@ export const putDealerProfile = async ({
 export const fetchDealerEntitlements = async (
   dealerId
 ): Promise<Entitlements> =>
-  withTokenRefresh(async () => {
-    try {
-      const result = await fetchPath(
-        Service.DEALER,
-        `dealers/${dealerId}/entitlements`
-      )
-      return result
-    } catch (error) {
-      return handleValidationError(error, { swallowErrors: true })
-    }
-  })
+  withTokenRefresh(
+    fetchPath(Service.DEALER, `dealers/${dealerId}/entitlements`)
+  )
 
 export const fetchDealerPromotion = async (
   dealerId: number
 ): Promise<DealerPromotion> =>
-  withTokenRefresh(async () => {
-    try {
-      const result = await fetchPath(
-        Service.DEALER,
-        `dealers/${dealerId}/promotion`
-      )
-      return result
-    } catch (error) {
-      return handleValidationError(error, { swallowErrors: true })
-    }
-  })
+  withTokenRefresh(fetchPath(Service.DEALER, `dealers/${dealerId}/promotion`))
 
 export const postDealerPromotion = async (
   dealerId: number,

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -6,14 +6,7 @@ import { Product, PurchaseAndUseProduct } from "../types/models/product"
 import { withTokenRefresh } from "../tokenRefresh"
 
 export const fetchProducts = async (): Promise<Product[]> =>
-  withTokenRefresh(async () => {
-    try {
-      const result = await fetchPath(Service.DEALER, "products")
-      return result
-    } catch (error) {
-      return handleValidationError(error, { swallowErrors: true })
-    }
-  })
+  withTokenRefresh(fetchPath(Service.DEALER, "products"))
 
 export const purchaseAndUseListingProduct = async (
   dealerId: number,

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -6,7 +6,7 @@ import { Product, PurchaseAndUseProduct } from "../types/models/product"
 import { withTokenRefresh } from "../tokenRefresh"
 
 export const fetchProducts = async (): Promise<Product[]> =>
-  withTokenRefresh(fetchPath(Service.DEALER, "products"))
+  withTokenRefresh(async () => fetchPath(Service.DEALER, "products"))
 
 export const purchaseAndUseListingProduct = async (
   dealerId: number,


### PR DESCRIPTION
With https://github.com/carforyou/carforyou-api-client-pkg/pull/167 some of the GET requests where not only wrapped in the token refresh handler but also in the validation error function which breaks the intended behavior as they are just loading data an no validation takes place, so the consumer will never expect an enveloped 200 to be returned in case there is a 404 or something else goes wrong...
