### PR TITLE
feat: add buyNow props to listing types

### DIFF
--- a/src/lib/factories/listing.ts
+++ b/src/lib/factories/listing.ts
@@ -112,6 +112,8 @@ const defaults: ListingType = {
       startDate: "2015-09-09",
     },
   ],
+  buyNowEligible: false,
+  buyNowInProgress: false,
 }
 
 export function Listing(attributes = {}): ListingType {
@@ -240,6 +242,8 @@ export function EmptyListing(): ListingType {
     weightTotal: undefined,
     wheelbase: undefined,
     enabledFeatures: [],
+    buyNowEligible: false,
+    buyNowInProgress: false,
   }
 }
 

--- a/src/types/models/listing.ts
+++ b/src/types/models/listing.ts
@@ -145,8 +145,6 @@ export interface SearchListingDealer {
   region: string
   dealerSourceGroup: DealerSourceGroup
   dealerType: DealerType
-  buyNowEligible: boolean
-  buyNowInProgress: boolean
 }
 
 interface BaseSearchListing {

--- a/src/types/models/listing.ts
+++ b/src/types/models/listing.ts
@@ -118,6 +118,8 @@ export interface Listing
   weightTotal: number
   wheelbase: number
   enabledFeatures: Feature[]
+  buyNowEligible: boolean
+  buyNowInProgress: boolean
 }
 
 export type ListingSource = "DEALER_PLATFORM" | "MANUAL" | "TUTTI" | "TDA"
@@ -143,6 +145,8 @@ export interface SearchListingDealer {
   region: string
   dealerSourceGroup: DealerSourceGroup
   dealerType: DealerType
+  buyNowEligible: boolean
+  buyNowInProgress: boolean
 }
 
 interface BaseSearchListing {
@@ -184,6 +188,8 @@ interface BaseSearchListing {
   bodyColorGroup: string
   conditionType: string
   consumptionCategory: string
+  buyNowEligible: boolean
+  buyNowInProgress: boolean
 }
 
 export interface ApiSearchListing extends BaseSearchListing {


### PR DESCRIPTION
Adds the new types to the Listing types.

refs: https://autoricardo-ag.slack.com/archives/C01A3ECLW7M/p1599821656058300