### PR TITLE
feat: replace leadsAnalytics with leadsImpressions and add fetchLeads…

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ Also accompanying modes and param types, as well as default values, are exported
 
 - [Analytics](https://carforyou-analytics-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics)
   - [fetchAnalyticsData](https://carforyou-analytics-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getListingsMetricsUsingPOST)
-  - [fetchLeadsImpressions](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getDealerLeadsImpressionsUsingPOST)
+  - [fetchLeadsAnalytics](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getDealerLeadsAnalyticsUsingPOST)
   - [fetchListingsAnalytics](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getDealerListingsAnalyticsUsingPOST),
-  - [fetchLeadsCount](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getDealerLeadsCountUsingGET)
+  - [fetchLeadsInteractionsAnalytics](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getDealerLeadsInteractionsUsingPOST)
 
 ## Mocking in tests
 

--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ Also accompanying modes and param types, as well as default values, are exported
 
 - [Analytics](https://carforyou-analytics-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics)
   - [fetchAnalyticsData](https://carforyou-analytics-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getListingsMetricsUsingPOST)
-  - [fetchLeadsAnalytics](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getDealerLeadsAnalyticsUsingPOST)
-  - [fetchListingsAnalytics](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getDealerListingsAnalyticsUsingPOST)
+  - [fetchLeadsImpressions](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getDealerLeadsImpressionsUsingPOST)
+  - [fetchListingsAnalytics](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getDealerListingsAnalyticsUsingPOST),
+  - [fetchLeadsCount](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Analytics/getDealerLeadsCountUsingGET)
 
 ## Mocking in tests
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,9 +203,9 @@ export {
 export { sendSavedSearch, deleteSavedSearch } from "./services/userNotification"
 export {
   fetchAnalyticsData,
-  fetchLeadsImpressions,
+  fetchLeadsAnalytics,
   fetchListingsAnalytics,
-  fetchLeadsCount,
+  fetchLeadsInteractionsAnalytics,
 } from "./services/analytics"
 export {
   fetchProducts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export {
   DealerEntitlements,
   Entitlements,
   CockpitAnalytics,
+  LeadsCount,
 } from "./types/models/index"
 
 export {
@@ -202,8 +203,9 @@ export {
 export { sendSavedSearch, deleteSavedSearch } from "./services/userNotification"
 export {
   fetchAnalyticsData,
-  fetchLeadsAnalytics,
+  fetchLeadsImpressions,
   fetchListingsAnalytics,
+  fetchLeadsCount,
 } from "./services/analytics"
 export {
   fetchProducts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ export {
   DealerEntitlements,
   Entitlements,
   CockpitAnalytics,
-  LeadsCount,
 } from "./types/models/index"
 
 export {

--- a/src/services/__tests__/analytics.test.ts
+++ b/src/services/__tests__/analytics.test.ts
@@ -1,7 +1,8 @@
 import {
   fetchAnalyticsData,
-  fetchLeadsImpressions,
+  fetchLeadsAnalytics,
   fetchListingsAnalytics,
+  fetchLeadsInteractionsAnalytics,
 } from "../analytics"
 
 describe("Analytics service", () => {
@@ -67,7 +68,7 @@ describe("Analytics service", () => {
     })
 
     it("fetches the data", async () => {
-      const data = await fetchLeadsImpressions({
+      const data = await fetchLeadsAnalytics({
         dealerId: 123,
         options: { accessToken: "TOKEN" },
       })
@@ -77,13 +78,57 @@ describe("Analytics service", () => {
     })
 
     it("sends query in the request body", async () => {
-      await fetchLeadsImpressions({
+      await fetchLeadsAnalytics({
         dealerId: 123,
         options: { accessToken: "TOKEN" },
       })
 
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`/dealers/123/leads/impressions`),
+        expect.stringContaining(`/dealers/123/leads/analytics`),
+        expect.objectContaining({
+          body: JSON.stringify({
+            function: "count",
+          }),
+        })
+      )
+    })
+  })
+
+  describe("#fetchLeadsInteractionsAnalytics", () => {
+    const analyticsData = [
+      {
+        type: "message",
+        count: 25,
+      },
+      {
+        type: "call",
+        count: 30,
+      },
+    ]
+
+    beforeEach(() => {
+      fetchMock.mockResponse(JSON.stringify(analyticsData))
+    })
+
+    it("fetches the data", async () => {
+      const data = await fetchLeadsInteractionsAnalytics({
+        dealerId: 123,
+        dimensions: ["type"],
+        options: { accessToken: "TOKEN" },
+      })
+
+      expect(data).toEqual(analyticsData)
+      expect(fetch).toHaveBeenCalled()
+    })
+
+    it("sends query in the request body", async () => {
+      await fetchLeadsAnalytics({
+        dealerId: 123,
+        options: { accessToken: "TOKEN" },
+      })
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/dealers/123/leads/analytics`),
         expect.objectContaining({
           body: JSON.stringify({
             function: "count",

--- a/src/services/__tests__/analytics.test.ts
+++ b/src/services/__tests__/analytics.test.ts
@@ -1,6 +1,6 @@
 import {
   fetchAnalyticsData,
-  fetchLeadsAnalytics,
+  fetchLeadsImpressions,
   fetchListingsAnalytics,
 } from "../analytics"
 
@@ -67,9 +67,8 @@ describe("Analytics service", () => {
     })
 
     it("fetches the data", async () => {
-      const data = await fetchLeadsAnalytics({
+      const data = await fetchLeadsImpressions({
         dealerId: 123,
-        query: { verificationDateFrom: "2020-10-20" },
         options: { accessToken: "TOKEN" },
       })
 
@@ -78,9 +77,8 @@ describe("Analytics service", () => {
     })
 
     it("sends query in the request body", async () => {
-      await fetchLeadsAnalytics({
+      await fetchLeadsImpressions({
         dealerId: 123,
-        query: { verificationDateFrom: "2020-10-20" },
         options: { accessToken: "TOKEN" },
       })
 

--- a/src/services/__tests__/analytics.test.ts
+++ b/src/services/__tests__/analytics.test.ts
@@ -83,11 +83,10 @@ describe("Analytics service", () => {
       })
 
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`/dealers/123/leads/analytics`),
+        expect.stringContaining(`/dealers/123/leads/impressions`),
         expect.objectContaining({
           body: JSON.stringify({
             function: "count",
-            query: { verificationDateFrom: "2020-10-20" },
           }),
         })
       )

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,10 +1,6 @@
-import { postData, ApiCallOptions, fetchPath } from "../base"
+import { postData, ApiCallOptions } from "../base"
 
-import {
-  DealerListingsAnalyticsData,
-  CockpitAnalytics,
-  LeadsCount,
-} from "../types/models"
+import { DealerListingsAnalyticsData, CockpitAnalytics } from "../types/models"
 
 export const fetchAnalyticsData = async ({
   dealerId,

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -27,28 +27,6 @@ export const fetchAnalyticsData = async ({
   })
 }
 
-export const fetchLeadsImpressions = async ({
-  dealerId,
-  dimensions,
-  options = {},
-}: {
-  dealerId: number
-  dimensions?: string[]
-  options?: ApiCallOptions
-}): Promise<Array<CockpitAnalytics>> => {
-  return postData({
-    path: `dealers/${dealerId}/leads/impressions`,
-    body: {
-      function: "count",
-      dimensions,
-    },
-    options: {
-      isAuthorizedRequest: true,
-      ...options,
-    },
-  })
-}
-
 export const fetchListingsAnalytics = async ({
   dealerId,
   dimensions,
@@ -71,15 +49,46 @@ export const fetchListingsAnalytics = async ({
   })
 }
 
-export const fetchLeadsCount = async ({
-  id,
+export const fetchLeadsAnalytics = async ({
+  dealerId,
+  dimensions,
   options = {},
 }: {
-  id: number
+  dealerId: number
+  dimensions?: string[]
   options?: ApiCallOptions
-}): Promise<LeadsCount> => {
-  return fetchPath({
-    path: `dealers/${id}/leads/count`,
-    options,
+}): Promise<Array<CockpitAnalytics>> => {
+  return postData({
+    path: `dealers/${dealerId}/leads/analytics`,
+    body: {
+      function: "count",
+      dimensions,
+    },
+    options: {
+      isAuthorizedRequest: true,
+      ...options,
+    },
+  })
+}
+
+export const fetchLeadsInteractionsAnalytics = async ({
+  dealerId,
+  dimensions,
+  options = {},
+}: {
+  dealerId: number
+  dimensions?: string[]
+  options?: ApiCallOptions
+}): Promise<Array<CockpitAnalytics>> => {
+  return postData({
+    path: `dealers/${dealerId}/leads-interactions/analytics`,
+    body: {
+      function: "count",
+      dimensions,
+    },
+    options: {
+      isAuthorizedRequest: true,
+      ...options,
+    },
   })
 }

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,6 +1,10 @@
-import { postData, ApiCallOptions } from "../base"
+import { postData, ApiCallOptions, fetchPath } from "../base"
 
-import { DealerListingsAnalyticsData, CockpitAnalytics } from "../types/models"
+import {
+  DealerListingsAnalyticsData,
+  CockpitAnalytics,
+  LeadsCount,
+} from "../types/models"
 
 export const fetchAnalyticsData = async ({
   dealerId,
@@ -23,23 +27,20 @@ export const fetchAnalyticsData = async ({
   })
 }
 
-export const fetchLeadsAnalytics = async ({
+export const fetchLeadsImpressions = async ({
   dealerId,
   dimensions,
-  query,
   options = {},
 }: {
   dealerId: number
   dimensions?: string[]
-  query?: { verificationDateFrom: string }
   options?: ApiCallOptions
 }): Promise<Array<CockpitAnalytics>> => {
   return postData({
-    path: `dealers/${dealerId}/leads/analytics`,
+    path: `dealers/${dealerId}/leads/impressions`,
     body: {
       function: "count",
       dimensions,
-      query,
     },
     options: {
       isAuthorizedRequest: true,
@@ -67,5 +68,18 @@ export const fetchListingsAnalytics = async ({
       isAuthorizedRequest: true,
       ...options,
     },
+  })
+}
+
+export const fetchLeadsCount = async ({
+  id,
+  options = {},
+}: {
+  id: number
+  options?: ApiCallOptions
+}): Promise<LeadsCount> => {
+  return fetchPath({
+    path: `dealers/${id}/leads/count`,
+    options,
   })
 }

--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -179,9 +179,3 @@ export interface CockpitAnalytics {
   count: number
   [key: string]: string | number
 }
-
-export interface LeadsCount {
-  callLeads: number
-  messageLeads: number
-  total: number
-}

--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -179,3 +179,9 @@ export interface CockpitAnalytics {
   count: number
   [key: string]: string | number
 }
+
+export interface LeadsCount {
+  callLeads: number
+  messageLeads: number
+  total: number
+}


### PR DESCRIPTION
BREAKING CHANGE

Ref:

> Endpoint GET /dealers/{dealerId}/leads/count should be used only for leads count. It returns exact number of message and call leads for the previous 30 days (sources are our DB and Matelso). Endpoint POST /dealers/{dealerId}/leads/impressions  is basically the same like the initial POST /dealers/{dealerId}/leads/analytics it returns leads stats for provided dimensions and function, we just removed time dimension from the request, we will always return data for the previous 30 days (source for this endpoint is GA).

