### PR TITLE
feat: transform listing to manual

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,7 @@ export {
   ListingValidationEndpoint,
   validateDealerListing,
   saveDealerListing,
+  transferDealerListingToManual,
 } from "./services/car/inventory"
 export {
   fetchBodyTypes,

--- a/src/lib/factories/listing.ts
+++ b/src/lib/factories/listing.ts
@@ -115,6 +115,7 @@ const defaults: ListingType = {
   ],
   buyNowEligible: false,
   buyNowInProgress: false,
+  transferredToManual: false,
 }
 
 export function Listing(attributes = {}): ListingType {
@@ -244,6 +245,7 @@ export function EmptyListing(): ListingType {
     enabledFeatures: [],
     buyNowEligible: false,
     buyNowInProgress: false,
+    transferredToManual: false,
   }
 }
 

--- a/src/services/car/__tests__/inventory.test.ts
+++ b/src/services/car/__tests__/inventory.test.ts
@@ -11,6 +11,7 @@ import {
   publishDealerListing,
   archiveDealerListing,
   unpublishDealerListing,
+  transferDealerListingToManual,
 } from "../inventory"
 
 import {
@@ -487,6 +488,39 @@ describe("CAR service", () => {
       ])
 
       const response = await unpublishDealerListing({
+        dealerId: 6,
+        listingId: 123,
+        options: requestOptionsMock,
+      })
+      expect(response).toEqual({ tag: "error", message, errors })
+    })
+  })
+
+  describe("#transferDealerListingToManual", () => {
+    it("transfers the listing to manual the listing", async () => {
+      fetchMock.mockResponse(JSON.stringify({ ok: true }))
+
+      const response = await transferDealerListingToManual({
+        dealerId: 6,
+        listingId: 123,
+        options: requestOptionsMock,
+      })
+      expect(response).toEqual({ tag: "success", result: {} })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/dealers/6/listings/123/transfer-to-manual"),
+        expect.objectContaining({ method: "POST" })
+      )
+    })
+
+    it("handles validation error", async () => {
+      const message = "not-valid"
+      const errors = [{ param: "price", message: "validation.field.not-empty" }]
+      fetchMock.mockResponses([
+        JSON.stringify({ message, errors }),
+        { status: 400 },
+      ])
+
+      const response = await transferDealerListingToManual({
         dealerId: 6,
         listingId: 123,
         options: requestOptionsMock,

--- a/src/services/car/inventory.ts
+++ b/src/services/car/inventory.ts
@@ -343,6 +343,34 @@ export const unpublishDealerListing = async ({
   }
 }
 
+export const transferDealerListingToManual = async ({
+  listingId,
+  dealerId,
+  options = {},
+}: {
+  listingId: number
+  dealerId: number
+  options: ApiCallOptions
+}): Promise<WithValidationError> => {
+  try {
+    await postData({
+      path: `dealers/${dealerId}/listings/${listingId}/transfer-to-manual`,
+      body: {},
+      options: {
+        isAuthorizedRequest: true,
+        ...options,
+      },
+    })
+  } catch (error) {
+    return handleValidationError(error)
+  }
+
+  return {
+    tag: "success",
+    result: {},
+  }
+}
+
 export const listingMandatoryFields = async ({
   dealerId,
   options = {},

--- a/src/types/models/listing.ts
+++ b/src/types/models/listing.ts
@@ -121,6 +121,7 @@ export interface Listing
   enabledFeatures: Feature[]
   buyNowEligible: boolean
   buyNowInProgress: boolean
+  transferredToManual: boolean
 }
 
 export type ListingSource = "DEALER_PLATFORM" | "MANUAL" | "TUTTI" | "TDA"


### PR DESCRIPTION
Adds a call to transform an imported listing to a manual one which will be used in the edit imported listings feature.