### PR TITLE
allow overriding the api version per-call

### DIFF
--- a/src/__tests__/base.test.ts
+++ b/src/__tests__/base.test.ts
@@ -53,6 +53,21 @@ describe("Base", () => {
       })
     })
 
+    it("allows overriding the version header", async () => {
+      const json = await fetchPath({
+        path: "/api/path",
+        options: { apiVersion: "v2" },
+      })
+
+      expect(json).toEqual({ ok: true })
+      expect(fetch).toHaveBeenCalledWith(expect.any(String), {
+        method: "GET",
+        headers: expect.objectContaining({
+          Accept: `application/vnd.carforyou.v2+json`,
+        }),
+      })
+    })
+
     it("allows setting custom headers", async () => {
       const json = await fetchPath({
         path: "api/path",

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -8,6 +8,8 @@ interface ApiClientConfig {
   debug?: boolean
 }
 
+export type ApiVersion = "v1" | "v2"
+
 class ApiClient {
   private static instance: ApiClient
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -3,7 +3,7 @@ import { WithFieldStats, FieldsStats } from "./types/fieldStats"
 import { Facets } from "./types/facets"
 import { ValidationError } from "./types/withValidationError"
 
-import apiClient from "./apiClient"
+import apiClient, { ApiVersion } from "./apiClient"
 import { ResponseError } from "./responseError"
 import { SearchListing } from "./types/models/listing"
 import { WithTopListing } from "./types/topListing"
@@ -54,11 +54,13 @@ const buildHeaders = ({
   headers = {},
   recaptchaToken,
   accessToken,
+  apiVersion,
   isAuthorizedRequest,
 }: RequestOptions): Record<string, string> => {
+  const version = apiVersion || apiClient.version
   return {
     "Content-Type": "application/json",
-    Accept: `application/vnd.carforyou.${apiClient.version}+json`,
+    Accept: `application/vnd.carforyou.${version}+json`,
     ...(isAuthorizedRequest ? getAuthorizationHeader(accessToken) : {}),
     ...(recaptchaToken ? { "Recaptcha-Token": recaptchaToken } : {}),
     ...headers,
@@ -74,12 +76,14 @@ export interface ApiCallOptions extends Omit<RequestInit, "method" | "body"> {
 
 interface AuthorizedApiCallOptions extends ApiCallOptions {
   isAuthorizedRequest?: boolean
+  apiVersion?: ApiVersion
 }
 
 type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
 
 interface RequestOptions extends AuthorizedApiCallOptions {
   method?: Method
+  apiVersion?: ApiVersion
 }
 
 export const fetchPath = async ({
@@ -95,6 +99,7 @@ export const fetchPath = async ({
     method = "GET",
     host = null,
     headers,
+    apiVersion,
     recaptchaToken,
     accessToken,
     isAuthorizedRequest,


### PR DESCRIPTION
ref https://autoricardo.atlassian.net/browse/CAR-5381

backend introduced a new version for the lead messages api. the api versioning applies per endpoint and we can't globally set the api version as we initially planned to. this adds capabilities to override the api version per-call