### PR TITLE
Split first/last name in message lead

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -67,6 +67,8 @@ const buildHeaders = ({
   }
 }
 
+type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+
 export interface ApiCallOptions extends Omit<RequestInit, "method" | "body"> {
   recaptchaToken?: string
   accessToken?: string
@@ -74,16 +76,9 @@ export interface ApiCallOptions extends Omit<RequestInit, "method" | "body"> {
   host?: string
 }
 
-interface AuthorizedApiCallOptions extends ApiCallOptions {
+interface RequestOptions extends ApiCallOptions {
+  apiVersion?: ApiVersion
   isAuthorizedRequest?: boolean
-  apiVersion?: ApiVersion
-}
-
-type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
-
-interface RequestOptions extends AuthorizedApiCallOptions {
-  method?: Method
-  apiVersion?: ApiVersion
 }
 
 export const fetchPath = async ({
@@ -93,7 +88,7 @@ export const fetchPath = async ({
 }: {
   path: string
   body?: string
-  options: RequestOptions
+  options: RequestOptions & { method?: Method }
 }) => {
   const {
     method = "GET",
@@ -146,7 +141,7 @@ export const postData = async ({
   path: string
   // eslint-disable-next-line @typescript-eslint/ban-types
   body: object
-  options: AuthorizedApiCallOptions
+  options: RequestOptions
 }) => {
   return fetchPath({
     path,
@@ -166,7 +161,7 @@ export const putData = async ({
   path: string
   // eslint-disable-next-line @typescript-eslint/ban-types
   body: object
-  options: AuthorizedApiCallOptions
+  options: RequestOptions
 }) => {
   return fetchPath({
     path,
@@ -183,7 +178,7 @@ export const deletePath = async ({
   options,
 }: {
   path: string
-  options: AuthorizedApiCallOptions
+  options: RequestOptions
 }) => {
   return fetchPath({
     path,

--- a/src/services/car/__tests__/messageLead.test.ts
+++ b/src/services/car/__tests__/messageLead.test.ts
@@ -7,7 +7,8 @@ describe("Car API", () => {
 
   const messageLead = (attributes = {}) => ({
     language: "de",
-    name: "Test",
+    firstName: "Test firstname",
+    lastName: "Test lastname",
     phone: "+41781234567",
     email: "test@test.com",
     message: "This is a message of a interested customer",
@@ -27,7 +28,9 @@ describe("Car API", () => {
         expect.any(String),
         expect.objectContaining({
           body: JSON.stringify({
-            name: "Test",
+            language: "de",
+            firstName: "Test firstname",
+            lastName: "Test lastname",
             phone: "+41781234567",
             email: "test@test.com",
             message: "This is a message of a interested customer",
@@ -35,6 +38,19 @@ describe("Car API", () => {
               available: true,
               services: ["some other cool video provider"],
             },
+          }),
+        })
+      )
+    })
+
+    it("calls api v2", async () => {
+      await sendMessageLead({ listingId: 12345, messageLead: messageLead() })
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Accept: "application/vnd.carforyou.v2+json",
           }),
         })
       )

--- a/src/services/car/__tests__/messageLead.test.ts
+++ b/src/services/car/__tests__/messageLead.test.ts
@@ -6,6 +6,7 @@ describe("Car API", () => {
   })
 
   const messageLead = (attributes = {}) => ({
+    language: "de",
     name: "Test",
     phone: "+41781234567",
     email: "test@test.com",

--- a/src/services/car/messageLead.ts
+++ b/src/services/car/messageLead.ts
@@ -36,7 +36,10 @@ export const sendMessageLead = async ({
           services: [...services, otherService].filter(Boolean),
         },
       },
-      options: otherOptions,
+      options: {
+        ...otherOptions,
+        apiVersion: "v2",
+      },
     })
 
     return {

--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -125,7 +125,8 @@ export interface MessageLead {
   language?: string
   email: string
   message: string
-  name: string
+  firstName: string
+  lastName: string
   phone: string
   videoCallPreference?: {
     available?: boolean

--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -122,11 +122,11 @@ export interface SavedSearch {
 }
 
 export interface MessageLead {
-  email?: string
   language?: string
-  message?: string
-  name?: string
-  phone?: string
+  email: string
+  message: string
+  name: string
+  phone: string
   videoCallPreference?: {
     available?: boolean
     services?: string[]


### PR DESCRIPTION
ref https://autoricardo.atlassian.net/browse/CAR-5381

backend introduced a new version for the lead messages api where the lead message name is split into first/last name. changes types and does the api v2 request