### PR TITLE
fix: added status in the query

### DIFF
--- a/src/services/reporting/__tests__/carSales.test.ts
+++ b/src/services/reporting/__tests__/carSales.test.ts
@@ -46,6 +46,7 @@ describe("Car Sales", () => {
     it("unwraps content from json", async () => {
       const data = await fetchCarSales({
         dealerId: 123,
+        status: "confirmed",
         options: { accessToken: "DUMMY TOKEN" },
       })
 
@@ -55,6 +56,7 @@ describe("Car Sales", () => {
     it("unwraps pagination from json", async () => {
       const data = await fetchCarSales({
         dealerId: 123,
+        status: "confirmed",
         options: { accessToken: "DUMMY TOKEN" },
       })
 
@@ -64,6 +66,7 @@ describe("Car Sales", () => {
     it("passes query in query string", async () => {
       await fetchCarSales({
         dealerId: 123,
+        status: "confirmed",
         page: 5,
         size: 25,
         options: { accessToken: "DUMMY TOKEN" },

--- a/src/services/reporting/__tests__/carSales.test.ts
+++ b/src/services/reporting/__tests__/carSales.test.ts
@@ -73,7 +73,9 @@ describe("Car Sales", () => {
       })
 
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/dealers/123/car-sales?page=5&size=25"),
+        expect.stringContaining(
+          "/dealers/123/car-sales?status=confirmed&page=5&size=25"
+        ),
         expect.any(Object)
       )
     })

--- a/src/services/reporting/carSales.ts
+++ b/src/services/reporting/carSales.ts
@@ -6,16 +6,18 @@ import { ApiCallOptions, fetchPath } from "../../base"
 
 export const fetchCarSales = async ({
   dealerId,
+  status,
   page,
   size,
   options = {},
 }: {
   dealerId: number
+  status: string
   page?: number
   size?: number
   options?: ApiCallOptions
 }): Promise<Paginated<CarSales>> => {
-  const query = toQueryString({ page, size })
+  const query = toQueryString({ status, page, size })
   return fetchPath({
     path: `dealers/${dealerId}/car-sales${query ? `?${query}` : ""}`,
     options: { isAuthorizedRequest: true, ...options },


### PR DESCRIPTION
I forgot to add the status as a parameter in the query when I extended the car-sales data.

https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Reporting/getDealerCarSalesUsingGET

![Screenshot 2021-02-22 at 12 14 13](https://user-images.githubusercontent.com/37380787/108700881-86b28780-7507-11eb-832e-3548f04672bb.png)



## Thank you 🔪