### PR TITLE
feat: add sorts EXTERNAL_LISTING_ID and PRODUCTION_YEAR

### DIFF
--- a/src/types/sort.ts
+++ b/src/types/sort.ts
@@ -7,6 +7,8 @@ export enum ListingSortTypeParams {
   MAKE_MODEL_A_Z = "MAKE_MODEL_A_Z",
   RELEVANCE = "RELEVANCE",
   PUBLISHING_DATE = "PUBLISHING_DATE",
+  EXTERNAL_LISTING_ID = "EXTERNAL_LISTING_ID",
+  PRODUCTION_YEAR = "PRODUCTION_YEAR",
 }
 
 export enum ListingSortOrderParams {


### PR DESCRIPTION
References
[CAR-6118](https://autoricardo.atlassian.net/browse/CAR-6118)
[CAR-6121](https://autoricardo.atlassian.net/browse/CAR-6121)

## Motivation and context

As a dealer, when visiting the overview page on DH, I want to be able to sort my listings by production year and external listing id
