### PR TITLE
feat: types and logic for lead messages created-date sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Also accompanying modes and param types, as well as default values, are exported
   - [`fetchTransmissionTypes`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory%20Data/getTransmissionTypesUsingGET)
 - [Lead](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Lead)
   - [`sendMessageLead`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Lead/createMessageLeadUsingPOST)
+  - `fetchDealerMessageLeads`
 - [Leasing](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing)
   - [`fetchLeasingFormUrl`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/generateLeasingProviderFormUrlUsingPOST)
   - [`sendLeasingInterest`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/createLeasingInterestUsingPOST)

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,9 @@ export {
   ListingSortParams,
   DealerSortTypeParams,
   DealerSortParams,
+  LeadSortOrderParams,
+  LeadSortParams,
+  LeadSortTypeParams,
 } from "./types/sort"
 
 export {
@@ -175,6 +178,7 @@ export { sendBuyNowApplication } from "./services/car/buyNowApplication"
 export {
   sendMessageLead,
   fetchDealerMessageLeads,
+  defaultLeadSort as defaultLeadListingsSort,
 } from "./services/car/messageLead"
 export { addPurchaseConfirmation } from "./services/carSaleTracking/buyerFeedback"
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export {
 export {
   SortOrderParams as ListingSortOrderParams,
   ListingSortTypeParams,
-  SortParams as ListingSortParams,
+  ListingSortParams,
   DealerSortTypeParams,
   DealerSortParams,
   SortOrderParams,

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,13 +93,13 @@ export {
 } from "./types/params/types"
 
 export {
-  ListingSortOrderParams,
+  SortOrderParams as ListingSortOrderParams,
   ListingSortTypeParams,
-  ListingSortParams,
+  SortParams as ListingSortParams,
   DealerSortTypeParams,
   DealerSortParams,
-  LeadSortOrderParams,
-  LeadSortParams,
+  SortOrderParams,
+  SortParams,
   LeadSortTypeParams,
 } from "./types/sort"
 

--- a/src/lib/__tests__/convertParams.test.ts
+++ b/src/lib/__tests__/convertParams.test.ts
@@ -1,12 +1,12 @@
 import { toSpringSortParams } from "../convertParams"
 
-import { ListingSortOrderParams, ListingSortTypeParams } from "../../types/sort"
+import { ListingSortTypeParams, SortOrderParams } from "../../types/sort"
 
 describe("toSpringParams", () => {
   it("converts newest to createdDate", () => {
     expect(
       toSpringSortParams({
-        sortOrder: ListingSortOrderParams.ASC,
+        sortOrder: SortOrderParams.ASC,
         sortType: ListingSortTypeParams.NEWEST,
       })
     ).toEqual("createdDate,desc")
@@ -15,7 +15,7 @@ describe("toSpringParams", () => {
   it("converts make model to two fields sort", () => {
     expect(
       toSpringSortParams({
-        sortOrder: ListingSortOrderParams.DESC,
+        sortOrder: SortOrderParams.DESC,
         sortType: ListingSortTypeParams.MAKE_MODEL_A_Z,
       })
     ).toEqual(["make,desc", "model,desc"])
@@ -33,7 +33,7 @@ describe("toSpringParams", () => {
     it(`converts the ${sortType} name to ${converted}`, () => {
       expect(
         toSpringSortParams({
-          sortOrder: ListingSortOrderParams.ASC,
+          sortOrder: SortOrderParams.ASC,
           sortType: sortType as ListingSortTypeParams,
         })
       ).toEqual(`${converted},asc`)

--- a/src/lib/convertParams.ts
+++ b/src/lib/convertParams.ts
@@ -1,6 +1,9 @@
 import toCamelCase from "./toCamelCase"
 
 import {
+  LeadSortOrderParams,
+  LeadSortParams,
+  LeadSortTypeParams,
   ListingSortOrderParams,
   ListingSortParams,
   ListingSortTypeParams,
@@ -29,6 +32,28 @@ export const toSpringSortParams = (elasticSortParams: ListingSortParams) => {
     // Uses two existing fields
     case ListingSortTypeParams.MAKE_MODEL_A_Z:
       return [`make,${convertedSortOrder}`, `model,${convertedSortOrder}`]
+    default:
+      return `${toCamelCase(sortType)},${convertedSortOrder}`
+  }
+}
+
+const reverseSortLeadOrder = (sortOrder: LeadSortOrderParams) => {
+  switch (sortOrder) {
+    case LeadSortOrderParams.ASC:
+      return LeadSortOrderParams.DESC
+    case LeadSortOrderParams.DESC:
+      return LeadSortOrderParams.ASC
+  }
+}
+
+export const toSpringSortLeadParams = (elasticSortParams: LeadSortParams) => {
+  const { sortOrder, sortType } = elasticSortParams
+  const convertedSortOrder = toCamelCase(sortOrder)
+
+  switch (sortType) {
+    // We use alias in elastic, field name is createdDate
+    case LeadSortTypeParams.NEWEST:
+      return `createdDate,${toCamelCase(reverseSortLeadOrder(sortOrder))}`
     default:
       return `${toCamelCase(sortType)},${convertedSortOrder}`
   }

--- a/src/lib/convertParams.ts
+++ b/src/lib/convertParams.ts
@@ -1,27 +1,26 @@
 import toCamelCase from "./toCamelCase"
 
 import {
-  LeadSortOrderParams,
-  LeadSortParams,
-  LeadSortTypeParams,
-  ListingSortOrderParams,
-  ListingSortParams,
   ListingSortTypeParams,
+  SortOrderParams,
+  SortParams,
 } from "../types/sort"
 
-const reverseSortOrder = (sortOrder: ListingSortOrderParams) => {
+const reverseSortOrder = (sortOrder: SortOrderParams) => {
   switch (sortOrder) {
-    case ListingSortOrderParams.ASC:
-      return ListingSortOrderParams.DESC
-    case ListingSortOrderParams.DESC:
-      return ListingSortOrderParams.ASC
+    case SortOrderParams.ASC:
+      return SortOrderParams.DESC
+    case SortOrderParams.DESC:
+      return SortOrderParams.ASC
   }
 }
 
 // search APIs generally use elastic search, with the exception of the archived listing search
 // for the ease of use to not have a need for multiple data types we convert existing sort params
 // to the ones accepted by spring
-export const toSpringSortParams = (elasticSortParams: ListingSortParams) => {
+export const toSpringSortParams = (
+  elasticSortParams: SortParams<ListingSortTypeParams>
+) => {
   const { sortOrder, sortType } = elasticSortParams
   const convertedSortOrder = toCamelCase(sortOrder)
 
@@ -32,28 +31,6 @@ export const toSpringSortParams = (elasticSortParams: ListingSortParams) => {
     // Uses two existing fields
     case ListingSortTypeParams.MAKE_MODEL_A_Z:
       return [`make,${convertedSortOrder}`, `model,${convertedSortOrder}`]
-    default:
-      return `${toCamelCase(sortType)},${convertedSortOrder}`
-  }
-}
-
-const reverseSortLeadOrder = (sortOrder: LeadSortOrderParams) => {
-  switch (sortOrder) {
-    case LeadSortOrderParams.ASC:
-      return LeadSortOrderParams.DESC
-    case LeadSortOrderParams.DESC:
-      return LeadSortOrderParams.ASC
-  }
-}
-
-export const toSpringSortLeadParams = (elasticSortParams: LeadSortParams) => {
-  const { sortOrder, sortType } = elasticSortParams
-  const convertedSortOrder = toCamelCase(sortOrder)
-
-  switch (sortType) {
-    // We use alias in elastic, field name is createdDate
-    case LeadSortTypeParams.NEWEST:
-      return `createdDate,${toCamelCase(reverseSortLeadOrder(sortOrder))}`
     default:
       return `${toCamelCase(sortType)},${convertedSortOrder}`
   }

--- a/src/services/car/__tests__/messageLead.test.ts
+++ b/src/services/car/__tests__/messageLead.test.ts
@@ -193,7 +193,7 @@ describe("Car API", () => {
 
       expect(fetch).toHaveBeenCalledWith(
         expect.stringMatching(
-          /\/dealers\/1234\/message-leads\?page=1&size=7&sort=createdDate%2Cdesc$/
+          /\/dealers\/1234\/message-leads\?page=1&size=7&sort=createdDate%2Casc$/
         ),
         expect.any(Object)
       )

--- a/src/services/car/__tests__/messageLead.test.ts
+++ b/src/services/car/__tests__/messageLead.test.ts
@@ -1,5 +1,6 @@
 import { fetchDealerMessageLeads, sendMessageLead } from "../messageLead"
 
+import { defaultLeadSort } from "../messageLead"
 import { PaginatedLeads } from "../../../lib/factories/paginated"
 import { SearchMessageLead as SearchMessageLeadFactory } from "../../../lib/factories/leads"
 
@@ -183,6 +184,7 @@ describe("Car API", () => {
         query: {
           page: 2,
           size: 7,
+          sort: defaultLeadSort,
         },
         options: {
           accessToken: "DummyTokenString",
@@ -190,7 +192,9 @@ describe("Car API", () => {
       })
 
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringMatching(/\/dealers\/1234\/message-leads\?page=1&size=7$/),
+        expect.stringMatching(
+          /\/dealers\/1234\/message-leads\?page=1&size=7&sort=createdDate%2Cdesc$/
+        ),
         expect.any(Object)
       )
     })
@@ -203,6 +207,7 @@ describe("Car API", () => {
           query: {
             page: 0,
             size: 7,
+            sort: {},
           },
         })
       } catch (err) {
@@ -220,6 +225,7 @@ describe("Car API", () => {
         query: {
           page: 0,
           size: 7,
+          sort: {},
         },
         options: {
           accessToken: "DummyTokenString",

--- a/src/services/car/__tests__/messageLead.test.ts
+++ b/src/services/car/__tests__/messageLead.test.ts
@@ -193,7 +193,7 @@ describe("Car API", () => {
 
       expect(fetch).toHaveBeenCalledWith(
         expect.stringMatching(
-          /\/dealers\/1234\/message-leads\?page=1&size=7&sort=createdDate%2Casc$/
+          /\/dealers\/1234\/message-leads\?page=1&size=7&sort=createdDate%2Cdesc$/
         ),
         expect.any(Object)
       )

--- a/src/services/car/messageLead.ts
+++ b/src/services/car/messageLead.ts
@@ -1,12 +1,12 @@
 import { WithValidationError } from "../../types/withValidationError"
-import { LeadSortOrderParams, LeadSortTypeParams } from "../../types/sort"
+import { LeadSortTypeParams, SortOrderParams } from "../../types/sort"
 import { LeadQueryParams } from "../../types/params/leads"
 import { Paginated } from "../../types/pagination"
 import { MessageLead, SearchMessageLead } from "../../types/models"
 import toQueryString from "../../lib/toQueryString"
+import toCamelCase from "../../lib/toCamelCase"
 import { createApiPathWithValidate } from "../../lib/path"
 import { pageOrDefault, sizeOrDefault } from "../../lib/pageParams"
-import { toSpringSortLeadParams } from "../../lib/convertParams"
 import {
   ApiCallOptions,
   fetchPath,
@@ -20,8 +20,8 @@ export const defaultDealerMessageLeadsPagination = {
 }
 
 export const defaultLeadSort = {
-  sortType: LeadSortTypeParams.NEWEST,
-  sortOrder: LeadSortOrderParams.ASC,
+  sortType: LeadSortTypeParams.CREATED_DATE,
+  sortOrder: SortOrderParams.ASC,
 }
 
 export const sendMessageLead = async ({
@@ -99,7 +99,9 @@ export const fetchDealerMessageLeads = async ({
   const queryParams = {
     page: pageOrDefault(page, defaultDealerMessageLeadsPagination),
     size: sizeOrDefault(size, defaultDealerMessageLeadsPagination),
-    sort: toSpringSortLeadParams(sortOrDefault),
+    sort: `${toCamelCase(sortOrDefault.sortType)},${toCamelCase(
+      sortOrDefault.sortOrder
+    )}`,
   }
 
   const path = `dealers/${dealerId}/message-leads?${toQueryString(queryParams)}`

--- a/src/services/car/messageLead.ts
+++ b/src/services/car/messageLead.ts
@@ -21,7 +21,7 @@ export const defaultDealerMessageLeadsPagination = {
 
 export const defaultLeadSort = {
   sortType: LeadSortTypeParams.CREATED_DATE,
-  sortOrder: SortOrderParams.ASC,
+  sortOrder: SortOrderParams.DESC,
 }
 
 export const sendMessageLead = async ({

--- a/src/services/car/messageLead.ts
+++ b/src/services/car/messageLead.ts
@@ -1,10 +1,12 @@
 import { WithValidationError } from "../../types/withValidationError"
-import { PaginationParams } from "../../types/params"
+import { LeadSortOrderParams, LeadSortTypeParams } from "../../types/sort"
+import { LeadQueryParams } from "../../types/params/leads"
 import { Paginated } from "../../types/pagination"
 import { MessageLead, SearchMessageLead } from "../../types/models"
 import toQueryString from "../../lib/toQueryString"
 import { createApiPathWithValidate } from "../../lib/path"
 import { pageOrDefault, sizeOrDefault } from "../../lib/pageParams"
+import { toSpringSortLeadParams } from "../../lib/convertParams"
 import {
   ApiCallOptions,
   fetchPath,
@@ -15,6 +17,11 @@ import {
 export const defaultDealerMessageLeadsPagination = {
   page: 0,
   size: 10,
+}
+
+export const defaultLeadSort = {
+  sortType: LeadSortTypeParams.NEWEST,
+  sortOrder: LeadSortOrderParams.ASC,
 }
 
 export const sendMessageLead = async ({
@@ -76,15 +83,23 @@ export const fetchDealerMessageLeads = async ({
   options = {},
 }: {
   dealerId: number
-  query: PaginationParams
+  query: LeadQueryParams
   options?: ApiCallOptions & { validateOnly?: boolean }
 }): Promise<Paginated<SearchMessageLead>> => {
   const { validateOnly, ...otherOptions } = options
-  const { page, size } = query
+  const { page, size, sort = {} } = query
+
+  const { sortOrder, sortType } = sort
+
+  const sortOrDefault = {
+    sortType: sortType || defaultLeadSort.sortType,
+    sortOrder: sortOrder || defaultLeadSort.sortOrder,
+  }
 
   const queryParams = {
     page: pageOrDefault(page, defaultDealerMessageLeadsPagination),
     size: sizeOrDefault(size, defaultDealerMessageLeadsPagination),
+    sort: toSpringSortLeadParams(sortOrDefault),
   }
 
   const path = `dealers/${dealerId}/message-leads?${toQueryString(queryParams)}`

--- a/src/services/search/__tests__/queryFormatting.test.ts
+++ b/src/services/search/__tests__/queryFormatting.test.ts
@@ -4,10 +4,7 @@ import {
   fetchListings,
 } from "../listingSearch"
 
-import {
-  ListingSortOrderParams,
-  ListingSortTypeParams,
-} from "../../../types/sort"
+import { ListingSortTypeParams, SortOrderParams } from "../../../types/sort"
 import { fetchPath, postData } from "../../../base"
 
 jest.mock("../../../base", () => ({
@@ -323,7 +320,7 @@ describe("SEARCH service", () => {
             dealerId,
             query: {
               sortType: ListingSortTypeParams.NEWEST,
-              sortOrder: ListingSortOrderParams.ASC,
+              sortOrder: SortOrderParams.ASC,
             },
             options: requestOptionsMock,
           })

--- a/src/services/search/listingSearch.ts
+++ b/src/services/search/listingSearch.ts
@@ -1,8 +1,8 @@
 import { WithTopListing } from "../../types/topListing"
 import {
-  ListingSortOrderParams,
-  ListingSortParams,
   ListingSortTypeParams,
+  SortOrderParams,
+  SortParams,
 } from "../../types/sort"
 import {
   ListingQueryParams,
@@ -88,12 +88,12 @@ export const fetchDealerArchivedListingsCount = async ({
 
 export const defaultUserSort = {
   sortType: ListingSortTypeParams.RELEVANCE,
-  sortOrder: ListingSortOrderParams.ASC,
+  sortOrder: SortOrderParams.ASC,
 }
 
 export const defaultDealerSort = {
   sortType: ListingSortTypeParams.NEWEST,
-  sortOrder: ListingSortOrderParams.ASC,
+  sortOrder: SortOrderParams.ASC,
 }
 
 export const defaultUserPagination = {
@@ -120,7 +120,7 @@ const searchForListings = ({
     includeTopListing?: boolean
     isAuthorizedRequest?: boolean
   }
-  defaultSort: ListingSortParams
+  defaultSort: SortParams<ListingSortTypeParams>
   defaultPagination: PaginationParams
 }) => {
   const { page, size, sortOrder, sortType, ...rest } = query
@@ -228,7 +228,7 @@ export const fetchDealerArchivedListings = async ({
   options = {},
 }: {
   dealerId: number
-  query?: ListingSortParams & PaginationParams
+  query?: SortParams<ListingSortTypeParams> & PaginationParams
   options?: ApiCallOptions
 }): Promise<Paginated<SearchListing>> => {
   const { page, size, sortOrder, sortType } = query

--- a/src/types/params/leads.ts
+++ b/src/types/params/leads.ts
@@ -1,7 +1,7 @@
-import { LeadSortParams } from "../../types/sort"
+import { LeadSortTypeParams, SortParams } from "../../types/sort"
 
 import { PaginationParams } from "./index"
 
 export interface LeadQueryParams extends PaginationParams {
-  sort: LeadSortParams
+  sort: SortParams<LeadSortTypeParams>
 }

--- a/src/types/params/leads.ts
+++ b/src/types/params/leads.ts
@@ -1,0 +1,7 @@
+import { LeadSortParams } from "../../types/sort"
+
+import { PaginationParams } from "./index"
+
+export interface LeadQueryParams extends PaginationParams {
+  sort: LeadSortParams
+}

--- a/src/types/params/listings.ts
+++ b/src/types/params/listings.ts
@@ -1,4 +1,4 @@
-import { ListingSortParams } from "../../types/sort"
+import { ListingSortTypeParams, SortParams } from "../../types/sort"
 
 import { PaginationParams } from "./index"
 
@@ -92,7 +92,7 @@ export interface ListingFilterParams {
 
 export interface DealerListingQueryParams
   extends PaginationParams,
-    ListingSortParams {
+    SortParams<ListingSortTypeParams> {
   manual?: boolean
   features?: string[]
 }

--- a/src/types/sort.ts
+++ b/src/types/sort.ts
@@ -1,3 +1,17 @@
+export enum SortOrderParams {
+  ASC = "ASC",
+  DESC = "DESC",
+}
+
+export interface SortParams<T> {
+  sortOrder?: SortOrderParams
+  sortType?: T
+}
+
+export enum LeadSortTypeParams {
+  CREATED_DATE = "CREATED_DATE",
+}
+
 export enum ListingSortTypeParams {
   NEWEST = "NEWEST",
   PRICE = "PRICE",
@@ -9,16 +23,6 @@ export enum ListingSortTypeParams {
   PUBLISHING_DATE = "PUBLISHING_DATE",
 }
 
-export enum ListingSortOrderParams {
-  ASC = "ASC",
-  DESC = "DESC",
-}
-
-export interface ListingSortParams {
-  sortOrder?: ListingSortOrderParams
-  sortType?: ListingSortTypeParams
-}
-
 export enum DealerSortTypeParams {
   ROTATION = "ROTATION",
   PREVIEW = "PREVIEW",
@@ -28,18 +32,4 @@ export interface DealerSortParams {
   type: DealerSortTypeParams
   seed?: number
   previewId?: number
-}
-
-export enum LeadSortTypeParams {
-  NEWEST = "NEWEST",
-}
-
-export enum LeadSortOrderParams {
-  ASC = "ASC",
-  DESC = "DESC",
-}
-
-export interface LeadSortParams {
-  sortOrder?: LeadSortOrderParams
-  sortType?: LeadSortTypeParams
 }

--- a/src/types/sort.ts
+++ b/src/types/sort.ts
@@ -23,6 +23,11 @@ export enum ListingSortTypeParams {
   PUBLISHING_DATE = "PUBLISHING_DATE",
 }
 
+export interface ListingSortParams {
+  sortOrder?: SortOrderParams
+  sortType?: ListingSortTypeParams
+}
+
 export enum DealerSortTypeParams {
   ROTATION = "ROTATION",
   PREVIEW = "PREVIEW",

--- a/src/types/sort.ts
+++ b/src/types/sort.ts
@@ -29,3 +29,17 @@ export interface DealerSortParams {
   seed?: number
   previewId?: number
 }
+
+export enum LeadSortTypeParams {
+  NEWEST = "NEWEST",
+}
+
+export enum LeadSortOrderParams {
+  ASC = "ASC",
+  DESC = "DESC",
+}
+
+export interface LeadSortParams {
+  sortOrder?: LeadSortOrderParams
+  sortType?: LeadSortTypeParams
+}


### PR DESCRIPTION
References CAR-6537

## Motivation and context
Handled needed API endpoint filter needed for `createdDate` sorting and introduced types and logic required. 
