### PR TITLE
feat: add new api to store dealer feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Also accompanying modes and param types, as well as default values, are exported
 
 - [Buyer feedback](https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Buyer%20Feedback)
   - [`addPurchaseConfirmation`](https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Buyer%20Feedback/addPurchaseConfirmationUsingPOST)
+- [Dealer feedback](https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Feedback)
+  - [`postDealerFeedback`](https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Feedback/createDealerFeedbackUsingPOST)
 
 ### [Buyer service](https://buyer-service.preprod.carforyou.ch/swagger-ui/index.html)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,6 +289,8 @@ export {
   deleteDealerSavedSearch,
 } from "./services/search/autoAlarm"
 
+export { postDealerFeedback } from "./services/carSaleTracking/dealerFeedback"
+
 export {
   Listing as ListingFactory,
   SearchListing as SearchListingFactory,

--- a/src/services/carSaleTracking/__tests__/dealerFeedback.test.ts
+++ b/src/services/carSaleTracking/__tests__/dealerFeedback.test.ts
@@ -1,53 +1,79 @@
 import { postDealerFeedback } from "../dealerFeedback"
-import { ResponseError } from "../../../responseError"
 
-describe("Car sale tracking API", () => {
-  beforeEach(fetchMock.resetMocks)
+describe("#postDealerFeedback", () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
 
-  describe("#postDealerFeedback", () => {
+  describe("valid parameters", () => {
     beforeEach(() => {
       fetchMock.mockResponse("")
     })
 
-    it("calls purchase confirmation", async () => {
-      await postDealerFeedback({
-        dealerId: 1234,
-        listingId: 4567,
-        purchaseConfirmed: true,
+    describe("validate only", () => {
+      it("calls validation endpoint", async () => {
+        await postDealerFeedback({
+          dealerId: 1234,
+          listingId: 4567,
+          purchaseConfirmed: true,
+          options: {
+            validateOnly: true,
+          },
+        })
+
+        expect(fetch).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /\/dealers\/1234\/listings\/4567\/car-sale\/dealer-feedback$/
+          ),
+          expect.any(Object)
+        )
       })
 
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /\/dealers\/1234\/listings\/4567\/car-sale\/dealer-feedback$/
-        ),
-        expect.any(Object)
-      )
+      it("returns a success", async () => {
+        const result = await postDealerFeedback({
+          dealerId: 1234,
+          listingId: 4567,
+          purchaseConfirmed: true,
+          options: {
+            validateOnly: true,
+          },
+        })
+
+        expect(result).toEqual({
+          tag: "success",
+          result: {},
+        })
+      })
     })
 
-    it("throws ResponseError 422", async () => {
-      fetchMock.mockResponse(
-        JSON.stringify({
-          message: "validation.purchase-confirmation-already-added",
-          description: "Purchase confirmation for DealerFeedback already added",
-          errors: [],
-        }),
-        {
-          status: 422,
-        }
-      )
-
-      let error
-      try {
+    describe("submit", () => {
+      it("calls submission endpoint", async () => {
         await postDealerFeedback({
           dealerId: 1234,
           listingId: 4567,
           purchaseConfirmed: true,
         })
-      } catch (err) {
-        error = err
-      }
 
-      expect(error).toEqual(new ResponseError(error.response))
+        expect(fetch).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /\/dealers\/1234\/listings\/4567\/car-sale\/dealer-feedback$/
+          ),
+          expect.any(Object)
+        )
+      })
+
+      it("returns a success", async () => {
+        const result = await postDealerFeedback({
+          dealerId: 1234,
+          listingId: 4567,
+          purchaseConfirmed: true,
+        })
+
+        expect(result).toEqual({
+          tag: "success",
+          result: {},
+        })
+      })
     })
   })
 })

--- a/src/services/carSaleTracking/__tests__/dealerFeedback.test.ts
+++ b/src/services/carSaleTracking/__tests__/dealerFeedback.test.ts
@@ -1,0 +1,53 @@
+import { postDealerFeedback } from "../dealerFeedback"
+import { ResponseError } from "../../../responseError"
+
+describe("Car sale tracking API", () => {
+  beforeEach(fetchMock.resetMocks)
+
+  describe("#postDealerFeedback", () => {
+    beforeEach(() => {
+      fetchMock.mockResponse("")
+    })
+
+    it("calls purchase confirmation", async () => {
+      await postDealerFeedback({
+        dealerId: 1234,
+        listingId: 4567,
+        purchaseConfirmed: true,
+      })
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /\/dealers\/1234\/listings\/4567\/car-sale\/dealer-feedback$/
+        ),
+        expect.any(Object)
+      )
+    })
+
+    it("throws ResponseError 422", async () => {
+      fetchMock.mockResponse(
+        JSON.stringify({
+          message: "validation.purchase-confirmation-already-added",
+          description: "Purchase confirmation for DealerFeedback already added",
+          errors: [],
+        }),
+        {
+          status: 422,
+        }
+      )
+
+      let error
+      try {
+        await postDealerFeedback({
+          dealerId: 1234,
+          listingId: 4567,
+          purchaseConfirmed: true,
+        })
+      } catch (err) {
+        error = err
+      }
+
+      expect(error).toEqual(new ResponseError(error.response))
+    })
+  })
+})

--- a/src/services/carSaleTracking/dealerFeedback.ts
+++ b/src/services/carSaleTracking/dealerFeedback.ts
@@ -1,4 +1,5 @@
-import { ApiCallOptions, postData } from "../../base"
+import { WithValidationError } from "../../types/withValidationError"
+import { ApiCallOptions, handleValidationError, postData } from "../../base"
 
 export const postDealerFeedback = async ({
   dealerId,
@@ -9,13 +10,20 @@ export const postDealerFeedback = async ({
   dealerId: number
   listingId: number
   purchaseConfirmed: boolean
-  options?: ApiCallOptions
-}): Promise<void> => {
-  return postData({
-    path: `dealers/${dealerId}/listings/${listingId}/car-sale/dealer-feedback`,
-    body: {
-      purchaseConfirmed,
-    },
-    options,
-  })
+  options?: ApiCallOptions & { validateOnly?: boolean }
+}): Promise<WithValidationError> => {
+  try {
+    await postData({
+      path: `dealers/${dealerId}/listings/${listingId}/car-sale/dealer-feedback`,
+      body: { purchaseConfirmed },
+      options,
+    })
+  } catch (error) {
+    return handleValidationError(error)
+  }
+
+  return {
+    tag: "success",
+    result: {},
+  }
 }

--- a/src/services/carSaleTracking/dealerFeedback.ts
+++ b/src/services/carSaleTracking/dealerFeedback.ts
@@ -1,0 +1,21 @@
+import { ApiCallOptions, postData } from "../../base"
+
+export const postDealerFeedback = async ({
+  dealerId,
+  listingId,
+  purchaseConfirmed,
+  options = {},
+}: {
+  dealerId: number
+  listingId: number
+  purchaseConfirmed: boolean
+  options?: ApiCallOptions
+}): Promise<void> => {
+  return postData({
+    path: `dealers/${dealerId}/listings/${listingId}/car-sale/dealer-feedback`,
+    body: {
+      purchaseConfirmed,
+    },
+    options,
+  })
+}


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/CAR-6693
API dealerFeedback -> https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Feedback/createDealerFeedbackUsingPOST

## Motivation and context
Add new api to store data collected by the dealer feedback.

## Thank you 🐊
