### PR TITLE
feat: hide dealer message leads

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Also accompanying modes and param types, as well as default values, are exported
 - [Lead](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Lead)
   - [`sendMessageLead`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Lead/createMessageLeadUsingPOST)
   - `fetchDealerMessageLeads`
+  - [`hideMessageLead`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Reporting/hideDealerMessageLeadUsingPOST)
 - [Leasing](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing)
   - [`fetchLeasingFormUrl`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/generateLeasingProviderFormUrlUsingPOST)
   - [`sendLeasingInterest`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/createLeasingInterestUsingPOST)

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,6 +204,7 @@ export {
 export {
   sendMessageLead,
   fetchDealerMessageLeads,
+  hideMessageLead,
   defaultLeadSort as defaultLeadListingsSort,
 } from "./services/car/messageLead"
 export { addPurchaseConfirmation } from "./services/carSaleTracking/buyerFeedback"

--- a/src/services/car/__tests__/messageLead.test.ts
+++ b/src/services/car/__tests__/messageLead.test.ts
@@ -261,7 +261,7 @@ describe("Car API", () => {
 
     it("handles validation error", async () => {
       const message = "not-valid"
-      const errors = [{ param: "price", message: "validation.field.not-empty" }]
+      const errors = [{ param: "email", message: "validation.field.not-empty" }]
       fetchMock.mockResponses([
         JSON.stringify({ message, errors }),
         { status: 400 },

--- a/src/services/car/__tests__/messageLead.test.ts
+++ b/src/services/car/__tests__/messageLead.test.ts
@@ -1,4 +1,8 @@
-import { fetchDealerMessageLeads, sendMessageLead } from "../messageLead"
+import {
+  fetchDealerMessageLeads,
+  hideMessageLead,
+  sendMessageLead,
+} from "../messageLead"
 
 import { defaultLeadSort } from "../messageLead"
 import { PaginatedLeads } from "../../../lib/factories/paginated"
@@ -234,6 +238,48 @@ describe("Car API", () => {
 
       expect(fetch).toHaveBeenCalled()
       expect(result).toEqual(PaginatedLeads([SearchMessageLeadFactory()]))
+    })
+  })
+
+  describe("#hideMessageLead", () => {
+    it("hides a message lead", async () => {
+      fetchMock.mockResponse(JSON.stringify({ ok: true }))
+
+      const response = await hideMessageLead({
+        dealerId: 1234,
+        messageLeadId: 501,
+        options: {
+          accessToken: "DummyTokenString",
+        },
+      })
+      expect(response).toEqual({ tag: "success", result: {} })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("dealers/1234/message-leads/501/hide"),
+        expect.objectContaining({ method: "POST" })
+      )
+    })
+
+    it("handles validation error", async () => {
+      const message = "not-valid"
+      const errors = [{ param: "price", message: "validation.field.not-empty" }]
+      fetchMock.mockResponses([
+        JSON.stringify({ message, errors }),
+        { status: 400 },
+      ])
+
+      const response = await hideMessageLead({
+        dealerId: 1234,
+        messageLeadId: 501,
+        options: {
+          accessToken: "DummyTokenString",
+        },
+      })
+      expect(response).toEqual({
+        tag: "error",
+        message,
+        errors,
+        globalErrors: [],
+      })
     })
   })
 })

--- a/src/services/car/messageLead.ts
+++ b/src/services/car/messageLead.ts
@@ -10,6 +10,7 @@ import { pageOrDefault, sizeOrDefault } from "../../lib/pageParams"
 import {
   ApiCallOptions,
   fetchPath,
+  handleValidationError,
   ignoreServerSideErrors,
   postData,
 } from "../../base"
@@ -113,4 +114,32 @@ export const fetchDealerMessageLeads = async ({
       isAuthorizedRequest: true,
     },
   })
+}
+
+export const hideMessageLead = async ({
+  dealerId,
+  messageLeadId,
+  options = {},
+}: {
+  dealerId: number
+  messageLeadId: number
+  options: ApiCallOptions
+}): Promise<WithValidationError> => {
+  try {
+    await postData({
+      path: `dealers/${dealerId}/message-leads/${messageLeadId}/hide`,
+      body: {},
+      options: {
+        isAuthorizedRequest: true,
+        ...options,
+      },
+    })
+  } catch (error) {
+    return handleValidationError(error)
+  }
+
+  return {
+    tag: "success",
+    result: {},
+  }
 }


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/CAR-6644

## Motivation and context

Added the delete api function for deleting/hiding dealer message leads 
`dealers/${dealerId}/message-leads/${messageLeadId}/hide`
