### PR TITLE
fix: never return undefined for date fields

### DIFF
--- a/src/lib/dateEncoding.ts
+++ b/src/lib/dateEncoding.ts
@@ -7,7 +7,7 @@ export const encodeDate = (date: DateType = {}) => {
 
 export const decodeDate = (date: string) => {
   if (!date) {
-    return
+    return null
   }
 
   try {
@@ -18,6 +18,6 @@ export const decodeDate = (date: string) => {
       year: parsedDate.getFullYear(),
     }
   } catch {
-    return
+    return null
   }
 }


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/CAR-5595

## Motivation and context

In listings, we get errors like the following and started cleaning `undefined` values with helpers. turns out this happens only for specific date fields, only on specific api endpoints:

```
SerializableError: Error serializing `.listing.firstRegistrationDate` returned from `getServerSideProps` in "/[languag
```

The solution is to return an explicit `null` and nextjs over in the projects is happy

