### PR TITLE
feat: resend message lead

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Also accompanying modes and param types, as well as default values, are exported
   - [`fetchDealerCallLeads`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Reporting/getAllDealerCallLeadsUsingGET)
   - [`hideMessageLead`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Reporting/hideDealerMessageLeadUsingPOST)
   - [`hideCallLead`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Reporting/hideDealerCallLeadUsingPOST)
-  - [`resendMessageLead`]
+  - [`resendMessageLead`](https://email-delivery-service.preprod.carforyou.ch/swagger-ui/index.html#/Email%20delivery/resendMessageLeadUsingPOST)
 - [Leasing](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing)
   - [`fetchLeasingFormUrl`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/generateLeasingProviderFormUrlUsingPOST)
   - [`sendLeasingInterest`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/createLeasingInterestUsingPOST)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Also accompanying modes and param types, as well as default values, are exported
   - [`fetchDealerCallLeads`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Reporting/getAllDealerCallLeadsUsingGET)
   - [`hideMessageLead`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Reporting/hideDealerMessageLeadUsingPOST)
   - [`hideCallLead`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Reporting/hideDealerCallLeadUsingPOST)
+  - [`resendMessageLead`]
 - [Leasing](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing)
   - [`fetchLeasingFormUrl`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/generateLeasingProviderFormUrlUsingPOST)
   - [`sendLeasingInterest`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Leasing/createLeasingInterestUsingPOST)

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,6 +210,7 @@ export {
   fetchDealerCallLeads,
   hideMessageLead,
   hideCallLead,
+  resendMessageLead,
   defaultLeadSort as defaultLeadListingsSort,
 } from "./services/car/messageLead"
 export { addPurchaseConfirmation } from "./services/carSaleTracking/buyerFeedback"

--- a/src/services/car/__tests__/messageLead.test.ts
+++ b/src/services/car/__tests__/messageLead.test.ts
@@ -3,6 +3,7 @@ import {
   fetchDealerMessageLeads,
   hideCallLead,
   hideMessageLead,
+  resendMessageLead,
   sendMessageLead,
 } from "../messageLead"
 
@@ -392,6 +393,48 @@ describe("Car API", () => {
       const response = await hideCallLead({
         dealerId: 1234,
         callLeadId: 501,
+        options: {
+          accessToken: "DummyTokenString",
+        },
+      })
+      expect(response).toEqual({
+        tag: "error",
+        message,
+        errors,
+        globalErrors: [],
+      })
+    })
+  })
+
+  describe("#resendMessageLead", () => {
+    it("resends a message lead", async () => {
+      fetchMock.mockResponse(JSON.stringify({ ok: true }))
+
+      const response = await resendMessageLead({
+        dealerId: 1234,
+        messageLeadId: 501,
+        options: {
+          accessToken: "DummyTokenString",
+        },
+      })
+      expect(response).toEqual({ tag: "success", result: {} })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("dealers/1234/message-leads/501/resend"),
+        expect.objectContaining({ method: "POST" })
+      )
+    })
+
+    it("handles validation error", async () => {
+      const message = "not-valid"
+      const errors = [{ param: "email", message: "validation.field.not-empty" }]
+      fetchMock.mockResponses([
+        JSON.stringify({ message, errors }),
+        { status: 400 },
+      ])
+
+      const response = await resendMessageLead({
+        dealerId: 1234,
+        messageLeadId: 501,
         options: {
           accessToken: "DummyTokenString",
         },

--- a/src/services/car/messageLead.ts
+++ b/src/services/car/messageLead.ts
@@ -217,3 +217,31 @@ export const hideCallLead = async ({
     result: {},
   }
 }
+
+export const resendMessageLead = async ({
+  dealerId,
+  messageLeadId,
+  options = {},
+}: {
+  dealerId: number
+  messageLeadId: number
+  options: ApiCallOptions
+}): Promise<WithValidationError> => {
+  try {
+    await postData({
+      path: `dealers/${dealerId}/message-leads/${messageLeadId}/resend`,
+      body: {},
+      options: {
+        isAuthorizedRequest: true,
+        ...options,
+      },
+    })
+  } catch (error) {
+    return handleValidationError(error)
+  }
+
+  return {
+    tag: "success",
+    result: {},
+  }
+}


### PR DESCRIPTION
References CAR-5985

## Motivation and context

Resend message leads. `dealers/${dealerId}/message-leads/${messageLeadId}/resend`
I'll add the swagger docs to the README once they're available