### PR TITLE
feat: allow association for inventory and suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Also accompanying modes and param types, as well as default values, are exported
   - [`fetchListing`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/getUsingGET_1)
   - [`fetchDealerMakes`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/getAllDealerMakesUsingGET)
   - [`fetchDealerModels`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/getAllDealerModelsUsingGET)
+  - [`fetchDealerOrAssociationMakes`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Inventory/getAllDealerMakesUsingGET)
+  - [`fetchDealerOrAssociationModels`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Inventory/getAllDealerMakesUsingGET_1)
   - [`fetchDealerListing`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/getUsingGET)
   - `validateDealerListing`
     - [for saving as draft](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/validateCreateUsingPOST)

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,8 @@ export {
   fetchDealerMakes,
   fetchDealerModels,
   fetchDealerListing,
+  fetchDealerOrAssociationMakes,
+  fetchDealerOrAssociationModels,
   publishDealerListing,
   archiveDealerListing,
   bulkArchiveDealerListings,

--- a/src/services/__tests__/dealer.test.ts
+++ b/src/services/__tests__/dealer.test.ts
@@ -1,3 +1,5 @@
+import { ResponseError } from "../../responseError"
+import { DealerSourceGroup, DealerType } from "../../types/models/index"
 import {
   fetchDealer,
   fetchDealerEntitlements,
@@ -10,10 +12,8 @@ import {
   putDealerProfile,
   putDealerPromotion,
   setImage,
-  setLogo,
+  setLogo
 } from "../dealer"
-import { DealerSourceGroup, DealerType } from "../../types/models/index"
-import { ResponseError } from "../../responseError"
 
 describe("Dealer", () => {
   const requestOptionsMock = {
@@ -28,6 +28,18 @@ describe("Dealer", () => {
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining(
           `dealers/suggestions?q=${encodeURIComponent(query)}`
+        ),
+        expect.any(Object)
+      )
+    })
+
+    it("queries the association", async () => {
+      const association = "association123"
+      await fetchDealerSuggestions({ association })
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `dealers/suggestions?association=${association}`
         ),
         expect.any(Object)
       )

--- a/src/services/__tests__/dealer.test.ts
+++ b/src/services/__tests__/dealer.test.ts
@@ -1,5 +1,3 @@
-import { ResponseError } from "../../responseError"
-import { DealerSourceGroup, DealerType } from "../../types/models/index"
 import {
   fetchDealer,
   fetchDealerEntitlements,
@@ -12,8 +10,10 @@ import {
   putDealerProfile,
   putDealerPromotion,
   setImage,
-  setLogo
+  setLogo,
 } from "../dealer"
+import { DealerSourceGroup, DealerType } from "../../types/models/index"
+import { ResponseError } from "../../responseError"
 
 describe("Dealer", () => {
   const requestOptionsMock = {

--- a/src/services/car/__tests__/inventory.test.ts
+++ b/src/services/car/__tests__/inventory.test.ts
@@ -3,6 +3,8 @@ import {
   bulkArchiveDealerListings,
   fetchDealerMakes,
   fetchDealerModels,
+  fetchDealerOrAssociationMakes,
+  fetchDealerOrAssociationModels,
   fetchListing,
   getAllDealerFrameNumbers,
   hideListing,
@@ -17,7 +19,6 @@ import {
   unpublishDealerListing,
   validateDealerListing,
 } from "../inventory"
-
 import { EmptyListing, Listing } from "../../../lib/factories/listing"
 import { encodeDate } from "../../../lib/dateEncoding"
 
@@ -76,6 +77,66 @@ describe("CAR service", () => {
 
       const data = await fetchDealerModels({ dealerId: 123, makeKey: "bmw" })
       expect(data).toEqual(models)
+      expect(fetch).toHaveBeenCalled()
+    })
+  })
+
+  describe("#fetchDealerOrAssociationMakes", () => {
+    it("fetches dealer data", async () => {
+      const makes = [
+        { make: "Audi", makeKey: "audi" },
+        { make: "BMW", makeKey: "bmw" },
+      ]
+      fetchMock.mockResponse(JSON.stringify(makes))
+
+      const data = await fetchDealerOrAssociationMakes({ dealerId: 123 })
+      expect(data).toEqual(makes)
+      expect(fetch).toHaveBeenCalled()
+    })
+
+    it("fetches association data", async () => {
+      const makes = [
+        { make: "Audi", makeKey: "audi" },
+        { make: "BMW", makeKey: "bmw" },
+      ]
+      fetchMock.mockResponse(JSON.stringify(makes))
+
+      const data = await fetchDealerOrAssociationMakes({
+        association: "association123",
+      })
+      expect(data).toEqual(makes)
+      expect(fetch).toHaveBeenCalled()
+    })
+  })
+
+  describe("#fetchDealerOrAssociationModels", () => {
+    it("fetches dealer data", async () => {
+      const makes = [
+        { make: "Audi", makeKey: "audi" },
+        { make: "BMW", makeKey: "bmw" },
+      ]
+      fetchMock.mockResponse(JSON.stringify(makes))
+
+      const data = await fetchDealerOrAssociationModels({
+        dealerId: 123,
+        makeKey: "bmw",
+      })
+      expect(data).toEqual(makes)
+      expect(fetch).toHaveBeenCalled()
+    })
+
+    it("fetches association data", async () => {
+      const makes = [
+        { make: "Audi", makeKey: "audi" },
+        { make: "BMW", makeKey: "bmw" },
+      ]
+      fetchMock.mockResponse(JSON.stringify(makes))
+
+      const data = await fetchDealerOrAssociationModels({
+        association: "association123",
+        makeKey: "bmw",
+      })
+      expect(data).toEqual(makes)
       expect(fetch).toHaveBeenCalled()
     })
   })

--- a/src/services/car/inventory.ts
+++ b/src/services/car/inventory.ts
@@ -1,6 +1,6 @@
 import { WithValidationError } from "../../types/withValidationError"
 import { Listing } from "../../types/models/listing"
-
+import toQueryString from "../../lib/toQueryString"
 import { decodeDate, encodeDate } from "../../lib/dateEncoding"
 import {
   ApiCallOptions,
@@ -55,6 +55,38 @@ export const fetchDealerModels = async ({
 }): Promise<Array<{ model: string; modelKey: string }>> => {
   return fetchPath({
     path: `dealers/${dealerId}/models?makeKey=${makeKey}`,
+    options,
+  })
+}
+
+export const fetchDealerOrAssociationMakes = async ({
+  dealerId,
+  association,
+  options = {},
+}: {
+  dealerId?: number
+  association?: string
+  options?: ApiCallOptions
+}): Promise<Array<{ make: string; makeKey: string }>> => {
+  return fetchPath({
+    path: `dealers/makes?${toQueryString({ dealerId, association })}`,
+    options,
+  })
+}
+
+export const fetchDealerOrAssociationModels = async ({
+  dealerId,
+  association,
+  makeKey,
+  options = {},
+}: {
+  dealerId?: number
+  makeKey: string
+  association?: string
+  options?: ApiCallOptions
+}): Promise<Array<{ model: string; modelKey: string }>> => {
+  return fetchPath({
+    path: `dealers/models?${toQueryString({ dealerId, association, makeKey })}`,
     options,
   })
 }

--- a/src/services/car/inventory.ts
+++ b/src/services/car/inventory.ts
@@ -63,14 +63,23 @@ export const fetchDealerModels = async ({
 export const fetchDealerOrAssociationMakes = async ({
   dealerId,
   association,
+  page,
+  size,
   options = {},
 }: {
   dealerId?: number
   association?: string
+  page?: number
+  size?: number
   options?: ApiCallOptions
 }): Promise<Paginated<{ make: string; makeKey: string }>> => {
   return fetchPath({
-    path: `dealers/makes?${toQueryString({ dealerId, association })}`,
+    path: `dealers/makes?${toQueryString({
+      dealerId,
+      association,
+      page,
+      size,
+    })}`,
     options,
   })
 }
@@ -79,15 +88,25 @@ export const fetchDealerOrAssociationModels = async ({
   dealerId,
   association,
   makeKey,
+  page,
+  size,
   options = {},
 }: {
   dealerId?: number
   association?: string
   makeKey: string
+  page?: number
+  size?: number
   options?: ApiCallOptions
 }): Promise<Paginated<{ model: string; modelKey: string }>> => {
   return fetchPath({
-    path: `dealers/models?${toQueryString({ dealerId, association, makeKey })}`,
+    path: `dealers/models?${toQueryString({
+      dealerId,
+      association,
+      makeKey,
+      page,
+      size,
+    })}`,
     options,
   })
 }

--- a/src/services/car/inventory.ts
+++ b/src/services/car/inventory.ts
@@ -1,14 +1,14 @@
-import { WithValidationError } from "../../types/withValidationError"
-import { Listing } from "../../types/models/listing"
-import toQueryString from "../../lib/toQueryString"
-import { decodeDate, encodeDate } from "../../lib/dateEncoding"
 import {
   ApiCallOptions,
   fetchPath,
   handleValidationError,
   postData,
-  putData,
+  putData
 } from "../../base"
+import { decodeDate, encodeDate } from "../../lib/dateEncoding"
+import toQueryString from "../../lib/toQueryString"
+import { Listing } from "../../types/models/listing"
+import { WithValidationError } from "../../types/withValidationError"
 
 const sanitizeListing = (json): Listing => {
   const { firstRegistrationDate, lastInspectionDate, ...rest } = json
@@ -81,8 +81,8 @@ export const fetchDealerOrAssociationModels = async ({
   options = {},
 }: {
   dealerId?: number
-  makeKey: string
   association?: string
+  makeKey: string
   options?: ApiCallOptions
 }): Promise<Array<{ model: string; modelKey: string }>> => {
   return fetchPath({

--- a/src/services/car/inventory.ts
+++ b/src/services/car/inventory.ts
@@ -1,14 +1,14 @@
+import { WithValidationError } from "../../types/withValidationError"
+import { Listing } from "../../types/models/listing"
+import toQueryString from "../../lib/toQueryString"
+import { decodeDate, encodeDate } from "../../lib/dateEncoding"
 import {
   ApiCallOptions,
   fetchPath,
   handleValidationError,
   postData,
-  putData
+  putData,
 } from "../../base"
-import { decodeDate, encodeDate } from "../../lib/dateEncoding"
-import toQueryString from "../../lib/toQueryString"
-import { Listing } from "../../types/models/listing"
-import { WithValidationError } from "../../types/withValidationError"
 
 const sanitizeListing = (json): Listing => {
   const { firstRegistrationDate, lastInspectionDate, ...rest } = json

--- a/src/services/car/inventory.ts
+++ b/src/services/car/inventory.ts
@@ -1,4 +1,5 @@
 import { WithValidationError } from "../../types/withValidationError"
+import { Paginated } from "../../types/pagination"
 import { Listing } from "../../types/models/listing"
 import toQueryString from "../../lib/toQueryString"
 import { decodeDate, encodeDate } from "../../lib/dateEncoding"
@@ -67,7 +68,7 @@ export const fetchDealerOrAssociationMakes = async ({
   dealerId?: number
   association?: string
   options?: ApiCallOptions
-}): Promise<Array<{ make: string; makeKey: string }>> => {
+}): Promise<Paginated<{ make: string; makeKey: string }>> => {
   return fetchPath({
     path: `dealers/makes?${toQueryString({ dealerId, association })}`,
     options,
@@ -84,7 +85,7 @@ export const fetchDealerOrAssociationModels = async ({
   association?: string
   makeKey: string
   options?: ApiCallOptions
-}): Promise<Array<{ model: string; modelKey: string }>> => {
+}): Promise<Paginated<{ model: string; modelKey: string }>> => {
   return fetchPath({
     path: `dealers/models?${toQueryString({ dealerId, association, makeKey })}`,
     options,

--- a/src/services/dealer.ts
+++ b/src/services/dealer.ts
@@ -1,17 +1,17 @@
+import { WithValidationError } from "../types/withValidationError"
+import { Language } from "../types/params"
+import { Paginated } from "../types/pagination"
+import { DealerPromotion } from "../types/models/dealerPromotion"
+import { DealerProfile } from "../types/models/dealerProfile"
+import { Dealer, DealerSuggestion, Entitlements } from "../types/models"
+import toQueryString from "../lib/toQueryString"
 import {
   ApiCallOptions,
   fetchPath,
   handleValidationError,
   postData,
-  putData
+  putData,
 } from "../base"
-import toQueryString from "../lib/toQueryString"
-import { Dealer, DealerSuggestion, Entitlements } from "../types/models"
-import { DealerProfile } from "../types/models/dealerProfile"
-import { DealerPromotion } from "../types/models/dealerPromotion"
-import { Paginated } from "../types/pagination"
-import { Language } from "../types/params"
-import { WithValidationError } from "../types/withValidationError"
 
 export const fetchDealer = async ({
   id,
@@ -39,9 +39,7 @@ export const fetchDealerSuggestions = async ({
   options?: ApiCallOptions
 }): Promise<Paginated<DealerSuggestion>> => {
   return fetchPath({
-    path: `dealers/suggestions?${
-      query ? "q=" + encodeURIComponent(query) : ""
-    }${association ? "association=" + association : ""}`,
+    path: `dealers/suggestions?${toQueryString({ association, q: query })}`,
     options,
   })
 }

--- a/src/services/dealer.ts
+++ b/src/services/dealer.ts
@@ -1,18 +1,17 @@
-import { WithValidationError } from "../types/withValidationError"
-import { Language } from "../types/params"
-import { Paginated } from "../types/pagination"
-import { DealerPromotion } from "../types/models/dealerPromotion"
-import { DealerProfile } from "../types/models/dealerProfile"
-import { Dealer, DealerSuggestion, Entitlements } from "../types/models"
-
-import toQueryString from "../lib/toQueryString"
 import {
   ApiCallOptions,
   fetchPath,
   handleValidationError,
   postData,
-  putData,
+  putData
 } from "../base"
+import toQueryString from "../lib/toQueryString"
+import { Dealer, DealerSuggestion, Entitlements } from "../types/models"
+import { DealerProfile } from "../types/models/dealerProfile"
+import { DealerPromotion } from "../types/models/dealerPromotion"
+import { Paginated } from "../types/pagination"
+import { Language } from "../types/params"
+import { WithValidationError } from "../types/withValidationError"
 
 export const fetchDealer = async ({
   id,
@@ -32,13 +31,17 @@ export const fetchDealer = async ({
 
 export const fetchDealerSuggestions = async ({
   query,
+  association,
   options = {},
 }: {
-  query: string
+  query?: string
+  association?: string
   options?: ApiCallOptions
 }): Promise<Paginated<DealerSuggestion>> => {
   return fetchPath({
-    path: `dealers/suggestions?q=${query ? encodeURIComponent(query) : query}`,
+    path: `dealers/suggestions?${
+      query ? "q=" + encodeURIComponent(query) : ""
+    }${association ? "association=" + association : ""}`,
     options,
   })
 }


### PR DESCRIPTION
References [CAR-5997](https://autoricardo.atlassian.net/browse/CAR-5997) and [CAR-5998](https://autoricardo.atlassian.net/browse/CAR-59988)

## Motivation and context

To fulfil the requirements for WLS we allow the optional `association` params in `fetchDealerSuggestions` and introduce new methods `fetchDealerOrAssociationModels` and `fetchDealerOrAssociationMakes`.