### PR TITLE
feat: remove deprecated fetchDealerModels call

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Also accompanying modes and param types, as well as default values, are exported
 - [Inventory](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory)
   - [`fetchListing`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/getUsingGET_1)
   - [`fetchDealerMakes`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/getAllDealerMakesUsingGET)
-  - [`fetchDealerModels`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/getAllDealerModelsUsingGET)
   - [`fetchDealerOrAssociationMakes`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Inventory/getAllDealerMakesUsingGET)
   - [`fetchDealerOrAssociationModels`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Inventory/getAllDealerMakesUsingGET_1)
   - [`fetchDealerListing`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/getUsingGET)

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,6 @@ export {
 export {
   fetchListing,
   fetchDealerMakes,
-  fetchDealerModels,
   fetchDealerListing,
   fetchDealerOrAssociationMakes,
   fetchDealerOrAssociationModels,

--- a/src/services/car/__tests__/inventory.test.ts
+++ b/src/services/car/__tests__/inventory.test.ts
@@ -2,7 +2,6 @@ import {
   archiveDealerListing,
   bulkArchiveDealerListings,
   fetchDealerMakes,
-  fetchDealerModels,
   fetchDealerOrAssociationMakes,
   fetchDealerOrAssociationModels,
   fetchListing,
@@ -63,20 +62,6 @@ describe("CAR service", () => {
 
       const data = await fetchDealerMakes({ dealerId: 123 })
       expect(data).toEqual(makes)
-      expect(fetch).toHaveBeenCalled()
-    })
-  })
-
-  describe("#fetchDealerModels", () => {
-    it("fetches data", async () => {
-      const models = [
-        { modelKey: "1er", model: "1er" },
-        { modelKey: "3er", model: "3er" },
-      ]
-      fetchMock.mockResponse(JSON.stringify(models))
-
-      const data = await fetchDealerModels({ dealerId: 123, makeKey: "bmw" })
-      expect(data).toEqual(models)
       expect(fetch).toHaveBeenCalled()
     })
   })

--- a/src/services/car/inventory.ts
+++ b/src/services/car/inventory.ts
@@ -45,21 +45,6 @@ export const fetchDealerMakes = async ({
   return fetchPath({ path: `inventory/dealers/${dealerId}/makes`, options })
 }
 
-export const fetchDealerModels = async ({
-  dealerId,
-  makeKey,
-  options = {},
-}: {
-  dealerId: number
-  makeKey: string
-  options?: ApiCallOptions
-}): Promise<Array<{ model: string; modelKey: string }>> => {
-  return fetchPath({
-    path: `dealers/${dealerId}/models?makeKey=${makeKey}`,
-    options,
-  })
-}
-
 export const fetchDealerOrAssociationMakes = async ({
   dealerId,
   association,


### PR DESCRIPTION
BREAKING CHANGE: method removed

Removes API that was created for the WLS needs, but then switched to a different one when we introduced dealer associations support.