### PR TITLE
fix: adjust buyerFeedbackEntries type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ export { WhatsappEntry, CallTrackingEntry } from "./types/models/tracking"
 export {
   BuyerFeedbackDealer,
   BuyerFeedbackListing,
+  BuyerFeedbackEntry,
   BuyerFeedbackEntries,
 } from "./types/models/buyerFeedbackBatch"
 

--- a/src/types/models/buyerFeedbackBatch.ts
+++ b/src/types/models/buyerFeedbackBatch.ts
@@ -17,7 +17,11 @@ export interface BuyerFeedbackListing
   dealer: BuyerFeedbackDealer
 }
 
-export interface BuyerFeedbackEntries {
+export interface BuyerFeedbackEntry {
   key: string
   listing: BuyerFeedbackListing
+}
+
+export interface BuyerFeedbackEntries {
+  buyerFeedbackEntries: BuyerFeedbackEntry[]
 }


### PR DESCRIPTION
## Reference
https://api.preprod.carforyou.ch/car-sale/buyer-feedback-batch/key/1

## Motivation and context

It was missing the `buyerFeedbackEntries` type.


