### PR TITLE
fix: ensure location filter is converted when getting count

### DIFF
--- a/src/services/search/__tests__/listingSearch.test.ts
+++ b/src/services/search/__tests__/listingSearch.test.ts
@@ -71,6 +71,19 @@ describe("SEARCH service", () => {
           })
         )
       })
+
+      it("converts the location filter", async () => {
+        await fetchListingCount({ query: { cityId: "12345", radius: "20" } })
+
+        expect(fetch).toHaveBeenCalledWith(
+          expect.stringMatching("listings/count"),
+          expect.objectContaining({
+            body: JSON.stringify({
+              query: { location: { cityId: "12345", radius: "20" } },
+            }),
+          })
+        )
+      })
     })
   })
 
@@ -162,6 +175,21 @@ describe("SEARCH service", () => {
       expect(listings.length).toEqual(1)
       expect(listings).toEqual(content)
       expect(fetch).toHaveBeenCalled()
+    })
+
+    it("converts the location filter", async () => {
+      await fetchListings({ query: { cityId: "12345", radius: "20" } })
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching("listings/search"),
+        expect.objectContaining({
+          body: JSON.stringify({
+            pagination: { page: 0, size: 24 },
+            sort: [{ order: "ASC", type: "RELEVANCE" }],
+            query: { location: { cityId: "12345", radius: "20" } },
+          }),
+        })
+      )
     })
 
     describe("Pagination", () => {

--- a/src/services/search/listingSearch.ts
+++ b/src/services/search/listingSearch.ts
@@ -33,7 +33,7 @@ export const fetchListingCount = async ({
   const json = await postData({
     path: "listings/count",
     body: {
-      query,
+      query: paramsToSearchRequest(query),
       ...(fieldsStats.length > 0 ? { includeFieldsStats: fieldsStats } : {}),
     },
     options: otherOptions,


### PR DESCRIPTION
References [CAR-7301](https://autoricardo.atlassian.net/browse/CAR-7301)

## Motivation and context
When getting listings count we were not merging `cityId` and `radius` into a location object, which resulted in count not being updated when applying the radius filter
