### PR TITLE
feat: add vehicleUniverse to the listing

### DIFF
--- a/src/lib/factories/listing.ts
+++ b/src/lib/factories/listing.ts
@@ -139,6 +139,7 @@ const defaults: ListingType = {
   useDefaultWarranty: false,
   useDefaultGeneralExternalNote: false,
   verified: false,
+  vehicleUniverse: "car",
 }
 
 export function Listing(attributes = {}): ListingType {
@@ -292,6 +293,7 @@ export function EmptyListing(): ListingType {
     useDefaultWarranty: undefined,
     useDefaultGeneralExternalNote: undefined,
     verified: false,
+    vehicleUniverse: "car",
   }
 }
 

--- a/src/types/models/listing.ts
+++ b/src/types/models/listing.ts
@@ -156,6 +156,7 @@ export interface Listing
   useDefaultWarranty: boolean
   useDefaultGeneralExternalNote: boolean
   verified: boolean
+  vehicleUniverse: string
 }
 
 export type ListingSource = "DEALER_PLATFORM" | "MANUAL" | "TUTTI" | "TDA"


### PR DESCRIPTION
## Motivation and context

BE is adding the vehicleUniverse on their side but we will change it and we will send it when we create a new listing
