### PR TITLE
feat: added carSalesTrackingSubscription data

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ Also accompanying modes and param types, as well as default values, are exported
   - [`putDealerDescription`](https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer/setDescriptionUsingPUT)
   - [`purchaseAndUseListingProduct`](https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Product/purchaseProductAndUseSubscriptionForListingUsingPOST)
   - [`bulkPurchaseAndUseListingsProduct`](https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Product/bulkPurchaseProductAndUseSubscriptionForListingUsingPOST)
+- [Product](https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Product)
+  - [`fetchCarSaleTrackingSubscription`](https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Product/getValidCarSaleTrackingSubscriptionUsingGET)
 
 ### [Email delivery service](https://email-delivery-service.preprod.carforyou.ch/swagger-ui/index.html)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ export {
   CarSalesListing,
   CarSales,
   CarSaleRejection,
+  CarSaleTrackingSubscription,
 } from "./types/models/carSales"
 
 export { WhatsappEntry, CallTrackingEntry } from "./types/models/tracking"
@@ -300,6 +301,8 @@ export {
 } from "./services/search/autoAlarm"
 
 export { postDealerFeedback } from "./services/carSaleTracking/dealerFeedback"
+
+export { fetchCarSaleTrackingSubscription } from "./services/carSaleTracking/subscription"
 
 export { fetchBuyerFeedbackBatch } from "./services/reporting/buyerFeedbackBatch"
 

--- a/src/services/carSaleTracking/__tests__/subscription.test.ts
+++ b/src/services/carSaleTracking/__tests__/subscription.test.ts
@@ -1,0 +1,33 @@
+import { fetchCarSaleTrackingSubscription } from "../subscription"
+
+describe("Product", () => {
+  beforeEach(fetchMock.resetMocks)
+
+  describe("#fetchCarSaleTrackingSubscription", () => {
+    const subscription = {
+      basePrice: 400,
+      capping: 2,
+      contingent: 3,
+      endDate: "2021-05-14T10:08:56.874Z",
+      numberOfInvoicedCarSales: 4,
+      pricePerCarSale: 200,
+      salesContactEmail: "teste@tester.com",
+      salesContactName: "Tester",
+      startDate: "2021-05-14T10:08:56.874Z",
+    }
+
+    beforeEach(() => {
+      fetchMock.mockResponse(JSON.stringify(subscription))
+    })
+
+    it("fetches car sales tracking subscription", async () => {
+      const data = await fetchCarSaleTrackingSubscription({
+        dealerId: 123,
+        options: { accessToken: "Token" },
+      })
+
+      expect(data).toEqual(subscription)
+      expect(fetch).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/services/carSaleTracking/subscription.ts
+++ b/src/services/carSaleTracking/subscription.ts
@@ -1,0 +1,18 @@
+import { CarSaleTrackingSubscription } from "../../types/models/carSales"
+
+import { ApiCallOptions, fetchPath } from "../../base"
+
+export const fetchCarSaleTrackingSubscription = async ({
+  dealerId,
+  options = {},
+}: {
+  dealerId: number
+  options?: ApiCallOptions
+}): Promise<CarSaleTrackingSubscription> =>
+  fetchPath({
+    path: `dealers/${dealerId}/car-sale-tracking-subscription`,
+    options: {
+      isAuthorizedRequest: true,
+      ...options,
+    },
+  })

--- a/src/types/models/carSales.ts
+++ b/src/types/models/carSales.ts
@@ -1,5 +1,17 @@
 import { ApiSearchListing } from "../../types/models/listing"
 
+export interface CarSaleTrackingSubscription {
+  basePrice: number
+  capping: number
+  contingent: number
+  endDate: string
+  numberOfInvoicedCarSales: number
+  pricePerCarSale: number
+  salesContactEmail: string
+  salesContactName: string
+  startDate: string
+}
+
 export interface Buyer {
   email: string
   firstName: string


### PR DESCRIPTION
References https://www.figma.com/file/p8RIdxT0mcEQRf1g2dzpHa/2021---Q1---Reporting-%26-Billing?node-id=1207%3A295

This API should cover widget 3 and also provide info for total number of sales for widget 2:
https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Product/getValidCarSaleTrackingSubscriptionUsingGET

## Motivation and context

Extend api-client for the widgets

## Thank you 🐄
