### PR TITLE
feat: added carSalesCount data

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Also accompanying modes and param types, as well as default values, are exported
   - [`addPurchaseConfirmation`](https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Buyer%20Feedback/addPurchaseConfirmationUsingPOST)
 - [Dealer feedback](https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Feedback)
   - [`postDealerFeedback`](https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Feedback/createDealerFeedbackUsingPOST)
+- [Car Sale](https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Car%20Sale)
+  - [`fetchCarSalesCount`](https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Car%20Sale/countCarSalesUsingGET)
 
 ### [Buyer service](https://buyer-service.preprod.carforyou.ch/swagger-ui/index.html)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,6 @@ export {
   CarSalesListing,
   CarSales,
   CarSaleRejection,
-  CarSaleCount,
   CarSaleTrackingSubscription,
 } from "./types/models/carSales"
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ export {
   CarSalesListing,
   CarSales,
   CarSaleRejection,
+  CarSaleCount,
 } from "./types/models/carSales"
 
 export { WhatsappEntry, CallTrackingEntry } from "./types/models/tracking"
@@ -150,6 +151,7 @@ export {
   fetchCarSales,
   rejectCarSales,
   deleteCarSalesRejection,
+  fetchCarSalesCount,
 } from "./services/reporting/carSales"
 
 export { fetchDealScores } from "./services/car/goodBadDealData"

--- a/src/services/reporting/__tests__/carSales.test.ts
+++ b/src/services/reporting/__tests__/carSales.test.ts
@@ -184,7 +184,7 @@ describe("Car Sales", () => {
         options: { accessToken: "Token" },
       })
 
-      expect(received.count).toEqual(count)
+      expect(received).toEqual(count)
       expect(fetch).toHaveBeenCalled()
     })
   })

--- a/src/services/reporting/__tests__/carSales.test.ts
+++ b/src/services/reporting/__tests__/carSales.test.ts
@@ -3,6 +3,7 @@ import { CarSaleRejection } from "index"
 import {
   deleteCarSalesRejection,
   fetchCarSales,
+  fetchCarSalesCount,
   rejectCarSales,
 } from "../carSales"
 import PaginatedFactory from "../../../lib/factories/paginated"
@@ -165,6 +166,26 @@ describe("Car Sales", () => {
         tag: "success",
         result: null,
       })
+    })
+  })
+
+  describe("#fetchCarSalesCount", () => {
+    const count = 5
+
+    beforeEach(() => {
+      fetchMock.mockResponse(JSON.stringify({ count }))
+    })
+
+    it("fetches car sales count", async () => {
+      const received = await fetchCarSalesCount({
+        dealerId: 123,
+        status: "draft",
+        hasRejection: false,
+        options: { accessToken: "Token" },
+      })
+
+      expect(received.count).toEqual(count)
+      expect(fetch).toHaveBeenCalled()
     })
   })
 })

--- a/src/services/reporting/carSales.ts
+++ b/src/services/reporting/carSales.ts
@@ -1,5 +1,5 @@
 import { Paginated } from "../../types/pagination"
-import { CarSales } from "../../types/models/carSales"
+import { CarSaleCount, CarSales } from "../../types/models/carSales"
 
 import toQueryString from "../../lib/toQueryString"
 import { CarSaleRejection, WithValidationError } from "../../index"
@@ -97,4 +97,22 @@ export const deleteCarSalesRejection = async ({
       },
     })
   )
+}
+
+export const fetchCarSalesCount = async ({
+  dealerId,
+  status,
+  hasRejection,
+  options = {},
+}: {
+  dealerId: number
+  status?: string
+  hasRejection?: boolean
+  options?: ApiCallOptions
+}): Promise<CarSaleCount> => {
+  const query = toQueryString({ status, hasRejection })
+  return fetchPath({
+    path: `dealers/${dealerId}/car-sales/count${query ? `?${query}` : ""}`,
+    options: { isAuthorizedRequest: true, ...options },
+  })
 }

--- a/src/services/reporting/carSales.ts
+++ b/src/services/reporting/carSales.ts
@@ -1,5 +1,5 @@
 import { Paginated } from "../../types/pagination"
-import { CarSaleCount, CarSales } from "../../types/models/carSales"
+import { CarSales } from "../../types/models/carSales"
 
 import toQueryString from "../../lib/toQueryString"
 import { CarSaleRejection, WithValidationError } from "../../index"
@@ -109,10 +109,11 @@ export const fetchCarSalesCount = async ({
   status?: string
   hasRejection?: boolean
   options?: ApiCallOptions
-}): Promise<CarSaleCount> => {
+}): Promise<number> => {
   const query = toQueryString({ status, hasRejection })
-  return fetchPath({
+  const { count } = await fetchPath({
     path: `dealers/${dealerId}/car-sales/count${query ? `?${query}` : ""}`,
     options: { isAuthorizedRequest: true, ...options },
   })
+  return count
 }

--- a/src/types/models/carSales.ts
+++ b/src/types/models/carSales.ts
@@ -1,9 +1,5 @@
 import { ApiSearchListing } from "../../types/models/listing"
 
-export interface CarSaleCount {
-  count: number
-}
-
 export interface CarSaleTrackingSubscription {
   basePrice: number
   capping: number

--- a/src/types/models/carSales.ts
+++ b/src/types/models/carSales.ts
@@ -1,5 +1,9 @@
 import { ApiSearchListing } from "../../types/models/listing"
 
+export interface CarSaleCount {
+  count: number
+}
+
 export interface Buyer {
   email: string
   firstName: string


### PR DESCRIPTION
References https://www.figma.com/file/p8RIdxT0mcEQRf1g2dzpHa/2021---Q1---Reporting-%26-Billing?node-id=1207%3A295

Sales vs Capping + current transactions - https://car-sale-tracking-service.preprod.carforyou.ch/swagger-ui/index.html#/Car%20Sale/countCarSalesUsingGET.

## Motivation and context

Extend api-client for the widgets

## Thank you 🦀