### PR TITLE
feat(bulk_endpoints): switch to new bulk endpoints

### DIFF
--- a/src/services/__tests__/product.test.ts
+++ b/src/services/__tests__/product.test.ts
@@ -107,7 +107,7 @@ describe("Products service", () => {
       })
       expect(fetch).toBeCalledWith(
         expect.stringContaining(
-          "/dealers/123/listings/products/purchase-and-use"
+          "/dealers/123/listings/products/bulk-purchase-and-use"
         ),
         expect.objectContaining({
           body: JSON.stringify({

--- a/src/services/car/__tests__/inventory.test.ts
+++ b/src/services/car/__tests__/inventory.test.ts
@@ -387,7 +387,7 @@ describe("CAR service", () => {
       })
       expect(response).toEqual({ tag: "success", result: {} })
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/dealers/6/listings/archive"),
+        expect.stringContaining("/dealers/6/listings/bulk-archive"),
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
@@ -506,7 +506,7 @@ describe("CAR service", () => {
       })
       expect(response).toEqual({ tag: "success", result: {} })
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/dealers/6/listings/transfer-to-manual"),
+        expect.stringContaining("/dealers/6/listings/bulk-transfer-to-manual"),
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({ elements: listingIds }),

--- a/src/services/car/inventory.ts
+++ b/src/services/car/inventory.ts
@@ -306,7 +306,7 @@ export const bulkArchiveDealerListings = async ({
 }): Promise<WithValidationError> => {
   try {
     await postData({
-      path: `dealers/${dealerId}/listings/archive`,
+      path: `dealers/${dealerId}/listings/bulk-archive`,
       body: {
         elements: listingIds,
       },
@@ -392,7 +392,7 @@ export const transferDealerListingsToManual = async ({
 }): Promise<WithValidationError> => {
   try {
     await postData({
-      path: `dealers/${dealerId}/listings/transfer-to-manual`,
+      path: `dealers/${dealerId}/listings/bulk-transfer-to-manual`,
       body: {
         elements: listingIds,
       },

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -65,7 +65,7 @@ export const bulkPurchaseAndUseListingsProduct = async ({
 }): Promise<WithValidationError<PurchaseAndUseProduct>> => {
   try {
     const result = await postData({
-      path: `dealers/${dealerId}/listings/products/purchase-and-use`,
+      path: `dealers/${dealerId}/listings/products/bulk-purchase-and-use`,
       body: {
         elements,
       },


### PR DESCRIPTION
References CAR-7468 (https://autoricardo.atlassian.net/browse/CAR-7468)

## Motivation and context

Switch to the new bulk endpoints:


/dealers/{dealerId}/listings/archive --> /dealers/{dealerId}/listings/bulk-archive ✅

/listings/set-buy-now-eligibility --> /listings/bulk-set-buy-now-eligibility (skipped)

/dealers/{dealerId}/listings/transfer-to-manual --> /dealers/{dealerId}/listings/bulk-transfer-to-manual ✅

/dealers/{dealerId}/listings/products/purchase-and-use --> /dealers/{dealerId}/listings/products/bulk-purchase-and-use ✅

/dealers/{dealerId}/listings/car-sale/dealer-feedback --> /dealers/{dealerId}/listings/car-sale/bulk-dealer-feedback (skipped)

Note: The `skipped` ones have been skipped because there is no bulk action implemented for those so far.