### PR TITLE
replace options with searchAttributes

### DIFF
--- a/src/types/params/listings.ts
+++ b/src/types/params/listings.ts
@@ -78,7 +78,7 @@ export interface ListingFilterParams {
   vehicleClass?: string[]
   hasImagesOnly?: boolean
   buyNowEligibleOnly?: boolean
-  options?: string[]
+  searchAttributes?: string[]
   imagesCountGroup?: string[]
 
   [key: string]:


### PR DESCRIPTION
References CAR-7482

## Motivation and context

Backend introduced a new filter 'searchAttributes' to replace deprecated 'options'
