### PR TITLE
fix: fetchFrameNumberTypes return empty array if no result

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 docker: &DOCKER_NODE
   docker:
-    - image: cimg/node:14.17.1
+    - image: cimg/node:14.17.2
 
 jobs:
   install:

--- a/src/services/__tests__/vehicle.test.ts
+++ b/src/services/__tests__/vehicle.test.ts
@@ -114,3 +114,30 @@ describe("#fetchFrameNumberOptions", () => {
     })
   })
 })
+
+describe("Query empty type ids", () => {
+  beforeEach(() => {
+    fetchMock
+      .once(
+        JSON.stringify({
+          frameNumber: "frameNumber",
+          productionYear: 2020,
+          types: [],
+        })
+      )
+      .once(JSON.stringify({ content: [] }))
+  })
+
+  it("returns empty result", async () => {
+    const response = await fetchFrameNumberTypes({
+      query: { frameNumber: "frameNumber", dealerId: 1316 },
+      options: requestOptionsMock,
+    })
+
+    expect(response.tag).toBe("success")
+
+    if (response.tag === "success") {
+      expect(response.result).toEqual({ content: [], pagination: null })
+    }
+  })
+})

--- a/src/services/vehicle.ts
+++ b/src/services/vehicle.ts
@@ -25,6 +25,16 @@ export const fetchFrameNumberTypes = async ({
       },
     })
 
+    if (!typeIds.length) {
+      return {
+        tag: "success",
+        result: {
+          content: [],
+          pagination: null,
+        },
+      }
+    }
+
     const types = await fetchTypes({
       query: { id: typeIds.map(({ id }) => id), page, size },
       options,


### PR DESCRIPTION
References [CAR-7875](https://autoricardo.atlassian.net/browse/CAR-7875)

## Motivation and context

https://autoricardo-ag.slack.com/archives/C8RRP2UQ4/p1624284136079200

When I search for VIN = WB1043001AZW29580 on Dealer Hub the list of results has 4132 pages because it returns an empty list of type ids which we use to fetch the types

## Test
https://github.com/carforyou/carforyou-dealerhub-web/pull/1389