### PR TITLE
feat: add referenceId to MessageLeadListing

### DIFF
--- a/src/lib/factories/leads.ts
+++ b/src/lib/factories/leads.ts
@@ -8,6 +8,7 @@ const searchMessageLeadDefaults: SearchMessageLeadType = {
   listingId: 501,
   listing: {
     externalListingId: "1234567",
+    referenceId: "123",
     image:
       "2019/09/17/11/13/13/1-aixam-mac-500-cabriolet-480-261485-7e5hF5fhFUiC.jpg",
     make: "Ford",
@@ -38,6 +39,7 @@ const searchCallLeadDefaults: SearchCallLeadType = {
   listingId: 501,
   listing: {
     externalListingId: "1234567",
+    referenceId: "123",
     firstRegistrationDate: "2021-03-18",
     id: 555,
     image:

--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -161,6 +161,7 @@ export interface MessageLeadListing {
   model: string
   price: number
   type: string
+  referenceId: string
 }
 
 export interface SearchMessageLead extends MessageLead {


### PR DESCRIPTION
References [CAR-7351](https://autoricardo.atlassian.net/browse/CAR-7351)
PR: https://github.com/carforyou/carforyou-dealerhub-web/pull/1402

## Motivation and context
As a dealer, I want to be able to easily identify the car that a potential customer is interested in in the leads center in dealer hub with my individual stock no. (= “Wagennummer”) so that I can work more efficiently and thus have more time to reply properly to my leads messages.
