### PR TITLE
feat: added hasBuyerProtectionOnly as filter param

### DIFF
--- a/src/types/params/listings.ts
+++ b/src/types/params/listings.ts
@@ -80,6 +80,7 @@ export interface ListingFilterParams {
   buyNowEligibleOnly?: boolean
   searchAttributes?: string[]
   imagesCountGroup?: string[]
+  hasBuyerProtectionOnly?: boolean
 
   [key: string]:
     | number


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/CAR-8084
Listing PR -> https://github.com/carforyou/carforyou-listings-web/pull/3414

## Motivation and context

To be able to pass the hasBuyerProtectionOnly filter in the query, I need to add it in the `ListingFilterParams`.

# Thank you 🌶
