### PR TITLE
feat: new saved search methods

### DIFF
--- a/src/services/__tests__/userNotification.test.ts
+++ b/src/services/__tests__/userNotification.test.ts
@@ -1,4 +1,9 @@
-import { deleteSavedSearch, sendSavedSearch } from "../userNotification"
+import {
+  deleteSavedSearch,
+  enableSavedSearch,
+  fetchSavedSearch,
+  sendSavedSearch,
+} from "../userNotification"
 
 describe("USER_NOTIFICATION service", () => {
   beforeEach(fetchMock.resetMocks)
@@ -81,6 +86,53 @@ describe("USER_NOTIFICATION service", () => {
 
       const response = await deleteSavedSearch({ key: "qwertyuiop" })
       expect(response.tag).toEqual("error")
+    })
+  })
+
+  describe("#enableSavedSearch", () => {
+    it("enables saved search", async () => {
+      fetchMock.mockResponse(JSON.stringify({ ok: true }))
+
+      const response = await enableSavedSearch({ key: "qwertyuiop" })
+      expect(response.tag).toEqual("success")
+      expect(fetch).toBeCalledWith(
+        expect.stringContaining("/saved-searches/key/qwertyuiop"),
+        expect.objectContaining({ method: "POST" })
+      )
+    })
+
+    it("handles response errors", async () => {
+      fetchMock.mockResponses([null, { status: 404 }])
+
+      const response = await enableSavedSearch({ key: "qwertyuiop" })
+      expect(response.tag).toEqual("error")
+    })
+  })
+
+  describe("#fetchSavedSearch", () => {
+    const savedSearch = {
+      email: "save@thesear.ch",
+      language: "de",
+      uiMetadata: {
+        searchPath: "?makeKeys=bmw",
+      },
+      searchQuery: {
+        makeKey: ["bmw"],
+      },
+    }
+
+    beforeEach(() => {
+      fetchMock.mockResponse(JSON.stringify(savedSearch))
+    })
+
+    it("returns data", async () => {
+      const fetched = await fetchSavedSearch({ key: "qwertyuiop" })
+
+      expect(fetched).toEqual(savedSearch)
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching("saved-searches/key/qwertyuiop"),
+        expect.any(Object)
+      )
     })
   })
 })

--- a/src/services/userNotification.ts
+++ b/src/services/userNotification.ts
@@ -4,6 +4,7 @@ import paramsToSearchRequest from "../lib/paramsToSearchRequest"
 import {
   ApiCallOptions,
   deletePath,
+  fetchPath,
   handleValidationError,
   postData,
 } from "../base"
@@ -54,3 +55,38 @@ export const deleteSavedSearch = async ({
     return handleValidationError(error, { swallowErrors: true })
   }
 }
+
+export const enableSavedSearch = async ({
+  key,
+  options = {},
+}: {
+  key: string
+  options?: ApiCallOptions
+}): Promise<WithValidationError> => {
+  try {
+    await postData({
+      path: `saved-searches/key/${key}/enable`,
+      body: {},
+      options,
+    })
+
+    return {
+      tag: "success",
+      result: {},
+    }
+  } catch (error) {
+    return handleValidationError(error, { swallowErrors: true })
+  }
+}
+
+export const fetchSavedSearch = async ({
+  key,
+  options = {},
+}: {
+  key: string
+  options?: ApiCallOptions
+}): Promise<SavedSearch> =>
+  fetchPath({
+    path: `saved-searches/key/${key}`,
+    options,
+  })


### PR DESCRIPTION
References CAR-7556

## Motivation and context

Adds two new API calls:
- `fetchSavedSearch`
- `enableSavedSearch`

That will be used in the saved search double opt-in.

**Note** The APIs are not yet implemented/exposed hence no link to the docs, there might still be some small changes 
- [ ] link to the docs once the APIs are live
