### PR TITLE
BREAKING CHANGE: remove needs assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,6 @@ Also accompanying modes and param types, as well as default values, are exported
   - [`fetchTypes`](https://inventory-search-service.preprod.carforyou.ch/swagger-ui/index.html#/Type%20Search/searchUsingPOST_3)
   - [`fetchTypeFacets`](https://inventory-search-service.preprod.carforyou.ch/swagger-ui/index.html#/Type%20Search/getFacetsUsingPOST_1)
 
-* [Needs Assessment](https://inventory-search-service.preprod.carforyou.ch/swagger-ui/index.html#/Needs_Assessment)
-
-  - [`fetchNeedsAssesmentListings`](https://inventory-search-service.preprod.carforyou.ch/swagger-ui/index.html#/Needs%20Assessment/searchUsingPOST_1)
-
 * [Saved Searches (Auto-Alarm)](https://inventory-search-service.preprod.carforyou.ch/swagger-ui/index.html#/Listing%20saved%20searches)
 
   - [`fetchSavedSearches`](https://inventory-search-service.preprod.carforyou.ch/swagger-ui/index.html#/Listing%20saved%20searches/getAllAutoAlarmsUsingGET)

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,7 +229,6 @@ export {
   fetchListings,
   fetchDealerListings,
   fetchDealerArchivedListings,
-  fetchNeedsAssessmentListings,
   defaultUserSort as defaultListingsSort,
   defaultUserPagination as defaultListingsPagination,
   defaultDealerSort as defaultDealerListingsSort,

--- a/src/services/search/__tests__/listingSearch.test.ts
+++ b/src/services/search/__tests__/listingSearch.test.ts
@@ -6,7 +6,6 @@ import {
   fetchListingCount,
   fetchListings,
   fetchMoneybackListings,
-  fetchNeedsAssessmentListings,
 } from "../listingSearch"
 import PaginatedFactory from "../../../lib/factories/paginated"
 import { SearchListing } from "../../../lib/factories/listing"
@@ -305,34 +304,6 @@ describe("SEARCH service", () => {
         expect(paginatedListings.pagination).toEqual(pagination)
         expect(fetch).toHaveBeenCalled()
       })
-    })
-  })
-
-  describe("#fetchNeedsAssessmentListings", () => {
-    const { content, pagination, fieldsStats } = PaginatedFactory([
-      SearchListing({ id: 1 }),
-    ])
-
-    beforeEach(() => {
-      fetchMock.mockResponse(
-        JSON.stringify({
-          content: content.map((listing) => ({
-            ...listing,
-            firstRegistrationDate: encodeDate(listing.firstRegistrationDate),
-          })),
-          ...pagination,
-          fieldsStats,
-        })
-      )
-    })
-
-    it("encodes the date", async () => {
-      const paginatedListings = await fetchNeedsAssessmentListings()
-      const listings = paginatedListings.content
-
-      expect(listings[0].firstRegistrationDate).toEqual(
-        content[0].firstRegistrationDate
-      )
     })
   })
 

--- a/src/services/search/listingSearch.ts
+++ b/src/services/search/listingSearch.ts
@@ -268,27 +268,6 @@ export const fetchDealerArchivedListings = async ({
   }
 }
 
-export const fetchNeedsAssessmentListings = async ({
-  query = {},
-  options = {},
-}: {
-  query?: ListingQueryParams
-  options?: ApiCallOptions & {
-    includeFieldsStats?: string[]
-    includeTopListing?: boolean
-  }
-} = {}): Promise<WithFieldStats<Paginated<SearchListing>>> => {
-  const response = await searchForListings({
-    path: "listings/needs-assessment/search",
-    query,
-    options,
-    defaultSort: defaultUserSort,
-    defaultPagination: defaultUserPagination,
-  })
-
-  return sanitizeListingResponse(response)
-}
-
 export const fetchMoneybackListings = async ({
   dealerId,
   query = {},


### PR DESCRIPTION
References [CAR-8474](https://autoricardo.atlassian.net/browse/CAR-8474)

## Motivation and context

We remove needs assessment completely from the app. Therefore, the fetch method is no longer needed.