### PR TITLE
fix: add a fallback value for gbdScore

### DIFF
--- a/src/services/search/__tests__/listingSearch.test.ts
+++ b/src/services/search/__tests__/listingSearch.test.ts
@@ -143,7 +143,7 @@ describe("SEARCH service", () => {
 
   describe("#fetchListings", () => {
     const { content, pagination, fieldsStats, topListing } = PaginatedFactory([
-      SearchListing({ id: 1 }),
+      SearchListing({ id: 1, gbdScore: null }),
     ])
 
     beforeEach(() => {
@@ -172,7 +172,8 @@ describe("SEARCH service", () => {
       const listings = paginatedListings.content
 
       expect(listings.length).toEqual(1)
-      expect(listings).toEqual(content)
+      expect(content.length).toEqual(1)
+      expect(content[0].id).toEqual(listings[0].id)
       expect(fetch).toHaveBeenCalled()
     })
 
@@ -190,6 +191,12 @@ describe("SEARCH service", () => {
           }),
         })
       )
+    })
+
+    it("falls back to gbdScore not-defined when field is null", async () => {
+      const paginatedListings = await fetchListings()
+
+      expect(paginatedListings.content[0].gbdScore).toEqual("not-defined")
     })
 
     describe("Pagination", () => {

--- a/src/services/search/listingSearch.ts
+++ b/src/services/search/listingSearch.ts
@@ -166,11 +166,15 @@ const searchForListings = ({
 
 const sanitizeListing = ({
   firstRegistrationDate,
+  gbdScore,
   ...listing
-}: ApiSearchListing): SearchListing => ({
-  ...listing,
-  firstRegistrationDate: decodeDate(firstRegistrationDate),
-})
+}: ApiSearchListing): SearchListing => {
+  return {
+    ...listing,
+    firstRegistrationDate: decodeDate(firstRegistrationDate),
+    gbdScore: gbdScore ? gbdScore : "not-defined",
+  }
+}
 
 function sanitizeListingResponse<
   T extends Paginated<ApiSearchListing> & { topListing: ApiSearchListing }


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/CAR-8584

## Motivation and context

some listings on the search service can have `null` values for `gdbdScore`, but our code expects a valid value from an enum
