### PR TITLE
fix: remove ids from make and models APIs

### DIFF
--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -3,7 +3,6 @@ import { DealerPromotionContent } from "./dealerPromotion"
 import { ListingFilterParams } from "../params/listings"
 
 export interface MappedValue {
-  id: number
   name: string
   key: string
 }


### PR DESCRIPTION
References CAR-8763

## Motivation and context

Since make and model APIs use `keys` for a long time now, BE decided to remove IDs from the responses.
