### PR TITLE
BREAKING CHANGE: Replace address with city for loan interest

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Also accompanying modes and param types, as well as default values, are exported
   - [`fetchBuyNowConfiguration`](https://buyer-service.preprod.carforyou.ch/swagger-ui/index.html#/Buy%20Now%20Configuration)
   - [`markBuyNowApplicationAsPaid`](https://buyer-service.preprod.carforyou.ch/swagger-ui/index.html#/Buy%20Now%20Application/markAsPaidUsingPOST)
 - [Loan](https://buyer-service.preprod.carforyou.ch/swagger-ui/index.html#/Loan%20Interest)
-  - [`createLoanInterest`](https://buyer-service.preprod.carforyou.ch/swagger-ui/index.html#/Loan%20Interest/createUsingPOST)
+  - [`createLoanInterest`](https://internal.carforyou.dev/api-docs/swagger-ui/#/Loan%20Interest/create_2)
   - [`calculateMonthlyRate`](https://listing-enrichment-service.preprod.carforyou.ch/swagger-ui/index.html#/Listing/calculateLoanUsingPOST)
 - [Favourites](https://internal.carforyou.dev/api-docs/swagger-ui/?urls.primaryName=buyer-service#/User%20Favorite%20Listing)
   - [`saveFavourite`](https://internal.carforyou.dev/api-docs/swagger-ui/?urls.primaryName=buyer-service#/User%20Favorite%20Listing/create)

--- a/src/services/car/__tests__/loan.test.ts
+++ b/src/services/car/__tests__/loan.test.ts
@@ -22,7 +22,7 @@ describe("#createLoanInterest", () => {
     workPermit: null,
     workPermitIssueDate: null,
     zipCode: "4600",
-    city: "Olte",
+    city: "Olten",
     ...attributes,
   })
 

--- a/src/services/car/__tests__/loan.test.ts
+++ b/src/services/car/__tests__/loan.test.ts
@@ -6,7 +6,6 @@ describe("#createLoanInterest", () => {
   const loanInterest = (
     attributes: Partial<LoanInterest> = {}
   ): LoanInterest => ({
-    address: "address",
     amount: 4000,
     birthdate: "2011-04-04",
     citizenshipCountryCode: "CH",
@@ -23,6 +22,7 @@ describe("#createLoanInterest", () => {
     workPermit: null,
     workPermitIssueDate: null,
     zipCode: "4600",
+    city: "Olte",
     ...attributes,
   })
 

--- a/src/types/models/loan.ts
+++ b/src/types/models/loan.ts
@@ -3,7 +3,6 @@ import { Language } from "../params"
 import { EmploymentType, Gender } from "./index"
 
 export interface LoanInterest {
-  address: string
   amount: number
   birthdate: string
   citizenshipCountryCode: string
@@ -20,6 +19,7 @@ export interface LoanInterest {
   workPermit?: "l" | "b" | "c" | "g"
   workPermitIssueDate?: string
   zipCode: string
+  city: string
 }
 
 export interface LoanCalculation {


### PR DESCRIPTION
References [CAR-9530](https://autoricardo.atlassian.net/browse/CAR-9530)

## Motivation and context

They need the city when they do a credit score request. here are a number of multizip-usages (meaning different towns use the same zip)
Some of them even across canton borders. In order to do credit checks, both specific
town + canton are relevant.
Therefore, a dedicated choice for city by the user is mandatory