### PR TITLE
fix: employment type order in loan interest

### DIFF
--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -52,13 +52,13 @@ export enum DealerEntitlements {
 }
 
 export enum EmploymentType {
-  UNEMPLOYED = "unemployed",
+  PERMANENT = "permanent",
   TEMPORARY = "temporary",
   SELF = "self-employed",
-  PERMANENT = "permanent",
-  PENSIONER = "pensioner",
-  HOURLY = "hourly-basis",
   FIXED = "fixed-term",
+  HOURLY = "hourly-basis",
+  PENSIONER = "pensioner",
+  UNEMPLOYED = "unemployed",
 }
 
 export enum Gender {

--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -51,6 +51,7 @@ export enum DealerEntitlements {
   PRINTCENTER = "print-center",
 }
 
+// the order was given by Credaris, please do not change without confirmation
 export enum EmploymentType {
   PERMANENT = "permanent",
   TEMPORARY = "temporary",


### PR DESCRIPTION
References [CAR-9548](https://autoricardo.atlassian.net/browse/CAR-9548)

## Motivation and context

Credaris requested to have a different order for employment types. Since we iterate over the object, we need to change it in api-client