### PR TITLE
BREAKING CHANGE: remove spinCode from dealer image api

### DIFF
--- a/src/types/models/listing.ts
+++ b/src/types/models/listing.ts
@@ -16,7 +16,6 @@ export interface DealerListingImages {
   detectedCarImageId: number
   images: ListingImage[]
   listingId: number
-  spinCode: string
 }
 
 export type LifecycleState = "active" | "inactive" | "gone"


### PR DESCRIPTION
References [Slack message](https://autoricardo-ag.slack.com/archives/C8RRP2UQ4/p1643644801340699?thread_ts=1643365928.002200&cid=C8RRP2UQ4)

## Motivation and context

We are not using spinCode in dealerhub and backend wants to drop it.