### PR TITLE
BREAKING CHANGE: remove image id for public apis

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export {
   Listing,
   ListingImage,
   ListingSourceGroup,
+  DealerListingImage,
   DealerListingImages,
   ListingSource,
   OtherServices,

--- a/src/lib/factories/listing.ts
+++ b/src/lib/factories/listing.ts
@@ -39,12 +39,10 @@ const defaults: ListingType = {
   dealerId: 1,
   images: [
     {
-      id: 1000001,
       externalUrl: "../../static/images/placeholder.png",
       s3Key: "2018/09/04/12/24/28/mercedes-benz-c-180-kompressor.jpg",
     },
     {
-      id: 1000002,
       externalUrl: "../../static/images/placeholder.png",
       s3Key: "2018/09/04/12/24/28/mercedes-benz-c-180-kompressor-1.jpg",
     },

--- a/src/types/models/listing.ts
+++ b/src/types/models/listing.ts
@@ -6,7 +6,7 @@ import {
 
 import { Date, DealerSourceGroup, DealerType, Location } from "./index"
 
-interface DealerListingImage {
+export interface DealerListingImage {
   id: number
   externalUrl: string
   s3Key: string

--- a/src/types/models/listing.ts
+++ b/src/types/models/listing.ts
@@ -6,15 +6,15 @@ import {
 
 import { Date, DealerSourceGroup, DealerType, Location } from "./index"
 
-export interface ListingImage {
+interface DealerListingImage {
   id: number
   externalUrl: string
   s3Key: string
 }
+export type ListingImage = Omit<DealerListingImage, "id">
 
 export interface DealerListingImages {
-  detectedCarImageId: number
-  images: ListingImage[]
+  images: DealerListingImage[]
   listingId: number
 }
 


### PR DESCRIPTION
References [CAR-9650](https://autoricardo.atlassian.net/browse/CAR-9650), [CAR-9271](https://autoricardo.atlassian.net/browse/CAR-9271)

## Motivation and context

backend would like to remove the field on their side. See here: https://autoricardo-ag.slack.com/archives/C8RRP2UQ4/p1643365928002200 and also here: https://github.com/carforyou/carforyou-integration-events-java/pull/139

## Related PRs
https://github.com/carforyou/carforyou-dealerhub-web/pull/1875
https://github.com/carforyou/carforyou-listings-web/pull/4132