### PR TITLE
feat: add new methods to bulk fetch data for comparison tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Also accompanying modes and param types, as well as default values, are exported
 - [Inventory](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory)
 
   - [`fetchListing`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/getUsingGET_1)
+  - [`bulkFetchListing`](https://internal.carforyou.dev/api-docs/swagger-ui/?urls.primaryName=inventory-search-service#/Listing%20Search/bulkGet)
   - [`fetchDealerMakes`](https://carforyou-service.preprod.carforyou.ch/swagger-ui/index.html#/Inventory/getAllDealerMakesUsingGET)
   - [`fetchDealerOrAssociationMakes`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Inventory/getAllDealerMakesUsingGET)
   - [`fetchDealerOrAssociationModels`](https://reporting-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer%20Inventory/getAllDealerMakesUsingGET_1)
@@ -119,6 +120,7 @@ Also accompanying modes and param types, as well as default values, are exported
 
 - [Listing](https://option-service.preprod.carforyou.ch/swagger-ui/index.html#/Listing)
   - [`fetchListingOptions`](https://option-service.preprod.carforyou.ch/swagger-ui/index.html#/Listing/getListingEquipmentUsingGET)
+  - [`bulkFetchListingOptions`](https://internal.carforyou.dev/api-docs/swagger-ui/?urls.primaryName=option-service#/Option/bulkGetListingEquipment)
   - [`fetchDealerListingOptions`](https://option-service.preprod.carforyou.ch/swagger-ui/index.html#/Listing/getDealerListingEquipmentUsingGET)
   - [`saveDealerListingOptions`](https://option-service.preprod.carforyou.ch/swagger-ui/index.html#/Listing/setListingEquipmentUsingPUT)
 - [Type](https://option-service.preprod.carforyou.ch/swagger-ui/index.html#/Type)
@@ -181,6 +183,7 @@ Also accompanying modes and param types, as well as default values, are exported
 
 - [Dealer](https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer)
   - [`fetchDealer`](https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer/getUsingGET)
+  - [`bulkFetchDealer`](https://internal.carforyou.dev/api-docs/swagger-ui/?urls.primaryName=dealer-service#/Dealer/bulkGet)
   - [`fetchDealerSuggestions`](https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer/getSuggestionsUsingGET)
   - [`fetchDealerProfile`](https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer/getProfileUsingGET)
   - [`putDealerProfile`](https://dealer-service.preprod.carforyou.ch/swagger-ui/index.html#/Dealer/updateProfileUsingPUT)

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export {
   Gender,
   Country,
   Question,
+  BulkFetchResponse,
 } from "./types/models/index"
 
 export { BuyNowApplication } from "./types/models/applications"

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,6 +198,7 @@ export {
 
 export {
   fetchListing,
+  bulkFetchListing,
   fetchDealerMakes,
   fetchDealerListing,
   fetchDealerOrAssociationMakes,
@@ -232,6 +233,7 @@ export { addPurchaseConfirmation } from "./services/carSaleTracking/buyerFeedbac
 
 export {
   fetchListingOptions,
+  bulkFetchListingOptions,
   fetchDealerListingOptions,
   saveDealerListingOptions,
 } from "./services/option/listing"
@@ -272,6 +274,7 @@ export {
 } from "./services/vehicle"
 export {
   fetchDealer,
+  bulkFetchDealer,
   fetchDealerSuggestions,
   fetchDealerProfile,
   putDealerProfile,

--- a/src/services/__tests__/dealer.test.ts
+++ b/src/services/__tests__/dealer.test.ts
@@ -1,4 +1,5 @@
 import {
+  bulkFetchDealer,
   deleteUser,
   fetchDealer,
   fetchDealerEntitlements,
@@ -62,6 +63,18 @@ describe("Dealer", () => {
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining("dealers/123"),
         expect.any(Object)
+      )
+    })
+  })
+
+  describe("#bulkFetchDealer", () => {
+    it("fetches the data", async () => {
+      await bulkFetchDealer({ dealerIds: [123, 321] })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/dealers/bulk-get"),
+        expect.objectContaining({
+          body: expect.stringContaining('{"elements":[123,321]}'),
+        })
       )
     })
   })

--- a/src/services/car/__tests__/inventory.test.ts
+++ b/src/services/car/__tests__/inventory.test.ts
@@ -1,4 +1,5 @@
 import {
+  bulkFetchListing,
   bulkUnpublishDealerListings,
   fetchDealerMakes,
   fetchDealerOrAssociationMakes,
@@ -15,6 +16,7 @@ import {
 } from "../inventory"
 import { EmptyListing, Listing } from "../../../lib/factories/listing"
 import { encodeDate } from "../../../lib/dateEncoding"
+import { ListingFactory } from "../../../index"
 
 const dealerId = 123
 const requestOptionsMock = {
@@ -45,6 +47,27 @@ describe("CAR service", () => {
 
       expect(fetch).toHaveBeenCalled()
       expect(fetchedListing).toEqual(listing)
+    })
+  })
+
+  describe("#bulkFetchListing", () => {
+    beforeEach(() => {
+      fetchMock.mockResponse(
+        JSON.stringify([
+          { id: 123, payload: ListingFactory({ id: 123 }) },
+          { id: 321, payload: ListingFactory({ id: 321 }) },
+        ])
+      )
+    })
+
+    it("fetches the data", async () => {
+      await bulkFetchListing({ listingIds: [123, 321] })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/listings/bulk-get"),
+        expect.objectContaining({
+          body: expect.stringContaining('{"elements":[123,321]}'),
+        })
+      )
     })
   })
 

--- a/src/services/car/__tests__/inventory.test.ts
+++ b/src/services/car/__tests__/inventory.test.ts
@@ -15,7 +15,7 @@ import {
   validateDealerListing,
 } from "../inventory"
 import { EmptyListing, Listing } from "../../../lib/factories/listing"
-import { encodeDate } from "../../../lib/dateEncoding"
+import * as dateEncoding from "../../../lib/dateEncoding"
 import { ListingFactory } from "../../../index"
 
 const dealerId = 123
@@ -35,9 +35,13 @@ describe("CAR service", () => {
       fetchMock.mockResponse(
         JSON.stringify({
           ...listing,
-          firstRegistrationDate: encodeDate(listing.firstRegistrationDate),
-          lastInspectionDate: encodeDate(listing.lastInspectionDate),
-          lastServiceDate: encodeDate(listing.lastServiceDate),
+          firstRegistrationDate: dateEncoding.encodeDate(
+            listing.firstRegistrationDate
+          ),
+          lastInspectionDate: dateEncoding.encodeDate(
+            listing.lastInspectionDate
+          ),
+          lastServiceDate: dateEncoding.encodeDate(listing.lastServiceDate),
         })
       )
     })
@@ -68,6 +72,40 @@ describe("CAR service", () => {
           body: expect.stringContaining('{"elements":[123,321]}'),
         })
       )
+    })
+
+    it("sanitizes the listing", async () => {
+      jest.spyOn(dateEncoding, "decodeDate")
+      fetchMock.mockResponse(
+        JSON.stringify([
+          {
+            id: 123,
+            payload: ListingFactory({
+              id: 123,
+              firstRegistrationDate: "2020-10-05",
+              lastInspectionDate: "2020-05-05",
+              lastServiceDate: "2018-06-05",
+            }),
+          },
+        ])
+      )
+      const listings = await bulkFetchListing({ listingIds: [123, 321] })
+      expect(listings[0].payload.firstRegistrationDate).toEqual({
+        month: 10,
+        year: 2020,
+      })
+      expect(listings[0].payload.lastInspectionDate).toEqual({
+        month: 5,
+        year: 2020,
+      })
+      expect(listings[0].payload.lastServiceDate).toEqual({
+        month: 6,
+        year: 2018,
+      })
+      expect(dateEncoding.decodeDate).toHaveBeenCalledTimes(3)
+      expect(dateEncoding.decodeDate).toHaveBeenNthCalledWith(1, "2020-10-05")
+      expect(dateEncoding.decodeDate).toHaveBeenNthCalledWith(2, "2020-05-05")
+      expect(dateEncoding.decodeDate).toHaveBeenNthCalledWith(3, "2018-06-05")
     })
   })
 

--- a/src/services/car/inventory.ts
+++ b/src/services/car/inventory.ts
@@ -1,7 +1,7 @@
-import { BulkFetchResponse } from "../../types/models"
 import { WithValidationError } from "../../types/withValidationError"
 import { Paginated } from "../../types/pagination"
 import { Listing } from "../../types/models/listing"
+import { BulkFetchResponse } from "../../types/models"
 import toQueryString from "../../lib/toQueryString"
 import { decodeDate, encodeDate } from "../../lib/dateEncoding"
 import {

--- a/src/services/car/inventory.ts
+++ b/src/services/car/inventory.ts
@@ -1,3 +1,4 @@
+import { BulkFetchResponse } from "../../types/models"
 import { WithValidationError } from "../../types/withValidationError"
 import { Paginated } from "../../types/pagination"
 import { Listing } from "../../types/models/listing"
@@ -39,6 +40,25 @@ export const fetchListing = async ({
   const listing = await fetchPath({ path: `listings/${id}`, options })
 
   return sanitizeListing(listing)
+}
+
+export const bulkFetchListing = async ({
+  listingIds,
+  options = {},
+}: {
+  listingIds: number[]
+  options?: ApiCallOptions
+}): Promise<BulkFetchResponse<Listing>[]> => {
+  const listings = await postData({
+    path: "listings/bulk-get",
+    body: { elements: listingIds },
+    options,
+  })
+
+  return listings.map((listing) => ({
+    id: listing.id,
+    payload: sanitizeListing(listing.payload),
+  }))
 }
 
 export const fetchDealerMakes = async ({

--- a/src/services/dealer.ts
+++ b/src/services/dealer.ts
@@ -4,7 +4,12 @@ import { Paginated } from "../types/pagination"
 import { DealerProfile } from "../types/models/dealerProfile"
 import { DealerPreferences } from "../types/models/dealerPreferences"
 import { UserAccount } from "../types/models/account"
-import { Dealer, DealerSuggestion, Entitlements } from "../types/models"
+import {
+  BulkFetchResponse,
+  Dealer,
+  DealerSuggestion,
+  Entitlements,
+} from "../types/models"
 import toQueryString from "../lib/toQueryString"
 import {
   ApiCallOptions,
@@ -27,6 +32,20 @@ export const fetchDealer = async ({
   const query = toQueryString({ language })
   return fetchPath({
     path: `dealers/${id}${query ? `?${query}` : ""}`,
+    options,
+  })
+}
+
+export const bulkFetchDealer = async ({
+  dealerIds,
+  options = {},
+}: {
+  dealerIds: number[]
+  options?: ApiCallOptions
+}): Promise<BulkFetchResponse<Dealer>[]> => {
+  return postData({
+    path: "dealers/bulk-get",
+    body: { elements: dealerIds },
     options,
   })
 }

--- a/src/services/option/__tests__/listing.test.ts
+++ b/src/services/option/__tests__/listing.test.ts
@@ -1,4 +1,5 @@
 import {
+  bulkFetchListingOptions,
   fetchDealerListingOptions,
   fetchListingOptions,
   saveDealerListingOptions,
@@ -27,6 +28,18 @@ describe("OPTION service", () => {
 
       expect(fetch).toHaveBeenCalled()
       expect(fetchedOptions).toEqual(options)
+    })
+  })
+
+  describe("#bulkFetchListingOptions", () => {
+    it("fetches the data", async () => {
+      await bulkFetchListingOptions({ listingIds: [123, 321], language: "de" })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/listings/equipment/bulk-get?language=de"),
+        expect.objectContaining({
+          body: expect.stringContaining('{"elements":[123,321]}'),
+        })
+      )
     })
   })
 

--- a/src/services/option/listing.ts
+++ b/src/services/option/listing.ts
@@ -33,7 +33,7 @@ export const bulkFetchListingOptions = async ({
   listingIds: number[]
   language: Language
   options?: ApiCallOptions
-}): Promise<BulkFetchResponse<Options>> => {
+}): Promise<BulkFetchResponse<Options>[]> => {
   return postData({
     path: `listings/equipment/bulk-get?language=${language}`,
     body: { elements: listingIds },

--- a/src/services/option/listing.ts
+++ b/src/services/option/listing.ts
@@ -1,11 +1,12 @@
 import { WithValidationError } from "../../types/withValidationError"
 import { Language } from "../../types/params"
 import { Listing } from "../../types/models/listing"
-import { Options } from "../../types/models"
+import { BulkFetchResponse, Options } from "../../types/models"
 import {
   ApiCallOptions,
   fetchPath,
   handleValidationError,
+  postData,
   putData,
 } from "../../base"
 
@@ -20,6 +21,22 @@ export const fetchListingOptions = async ({
 }): Promise<Options> => {
   return fetchPath({
     path: `listings/${listingId}/equipment?language=${language}`,
+    options,
+  })
+}
+
+export const bulkFetchListingOptions = async ({
+  listingIds,
+  language,
+  options = {},
+}: {
+  listingIds: number[]
+  language: Language
+  options?: ApiCallOptions
+}): Promise<BulkFetchResponse<Options>> => {
+  return postData({
+    path: `listings/equipment/bulk-get?language=${language}`,
+    body: { elements: listingIds },
     options,
   })
 }

--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -251,3 +251,8 @@ export interface DealerAnalytics {
 export interface BuyNowConfiguration {
   paymentAvailable: boolean
 }
+
+export interface BulkFetchResponse<T> {
+  id: number
+  payload: T
+}


### PR DESCRIPTION
References [CAR-9729](https://autoricardo.atlassian.net/browse/CAR-9729)

## Motivation and context

To fetch the data for the comparison tool, bulk fetch methods have been introduced. To see how they are used, here is the related PR in listings: https://github.com/carforyou/carforyou-listings-web/pull/4137