### PR TITLE
feat: expose searchAttributes

### DIFF
--- a/src/lib/factories/listing.ts
+++ b/src/lib/factories/listing.ts
@@ -157,6 +157,7 @@ const defaults: ListingType = {
   useDefaultGeneralExternalNote: false,
   verified: false,
   vehicleUniverse: "car",
+  searchAttributes: [],
 }
 
 export function Listing(attributes = {}): ListingType {
@@ -329,6 +330,7 @@ export function EmptyListing(): ListingType {
     useDefaultGeneralExternalNote: undefined,
     verified: false,
     vehicleUniverse: "car",
+    searchAttributes: [],
   }
 }
 

--- a/src/types/models/listing.ts
+++ b/src/types/models/listing.ts
@@ -165,6 +165,7 @@ export interface Listing
   firstStablePrice: number
   priceReductionPercentage: number
   hasReducedPrice: boolean
+  searchAttributes: string[]
 }
 
 export type ListingSource = "DEALER_PLATFORM" | "MANUAL" | "TUTTI" | "TDA"


### PR DESCRIPTION
References [CAR-9733](https://autoricardo.atlassian.net/browse/CAR-9733)

## Motivation and context

Options that we want to show in the comparison tool are the ones that are used in the options filter (so that there is some unification and ability to compare). They are exposed as `searchAttributes` on the listing object.

**_note_** This PR is a perfect example of how API types from swagger would save us work
